### PR TITLE
Include file ID in search results

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1423,7 +1423,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           supportsAllDrives: true
         });
 
-        const fileList = res.data.files?.map((f: drive_v3.Schema$File) => `${f.name} (${f.mimeType})`).join("\n") || '';
+        const fileList = res.data.files?.map((f: drive_v3.Schema$File) => `${f.name} (ID: ${f.id}, ${f.mimeType})`).join("\n") || '';
         log('Search results', { query: userQuery, resultCount: res.data.files?.length });
 
         let response = `Found ${res.data.files?.length ?? 0} files:\n${fileList}`;


### PR DESCRIPTION
## Summary

The `search` tool was already fetching file IDs via the `fields` parameter (`files(id, name, mimeType, modifiedTime, size)`), but not including them in the response. This made it difficult to use the search results with other tools like `formatGoogleDocText`, `updateGoogleDoc`, etc., that require file IDs.

## Changes

- Updated the search result format to include file ID
- Format now matches `listFolder` output: `{name} (ID: {id}, {mimeType})`

## Before
```
Found 2 files:
proposal.docx (application/vnd.google-apps.document)
meeting-notes.docx (application/vnd.google-apps.document)
```

## After
```
Found 2 files:
proposal.docx (ID: 1abc2def3ghi, application/vnd.google-apps.document)
meeting-notes.docx (ID: 4jkl5mno6pqr, application/vnd.google-apps.document)
```

## Use Case

Users can now search for a file and directly use the returned ID with other tools:
1. `search` - get file ID from results
2. `formatGoogleDocText` / `updateGoogleDoc` - use the file ID