### PR TITLE
feat: add downloadFile tool for streaming Drive files to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ coverage/
 *.tmp
 *.temp
 .cache/
+.tmp-test/

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
         "auth": "node dist/index.js auth",
         "watch": "node scripts/build.js --watch",
         "prepare": "npm run build",
-        "test": "echo \"No tests yet\" && exit 0",
+        "test": "npm run test:unit",
+        "test:build": "shx rm -rf .tmp-test && tsc -p tsconfig.test.json",
+        "test:unit": "npm run test:build && node --test .tmp-test/test/**/*.test.js",
         "lint": "tsc --noEmit"
     },
     "dependencies": {

--- a/src/download-file.ts
+++ b/src/download-file.ts
@@ -1,0 +1,253 @@
+import { createWriteStream, existsSync, renameSync, statSync, unlinkSync } from 'fs';
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'path';
+import { pipeline } from 'stream/promises';
+
+export const GOOGLE_WORKSPACE_EXPORT_FORMATS: Record<string, Record<string, string>> = {
+  'application/vnd.google-apps.document': {
+    pdf: 'application/pdf',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    md: 'text/markdown',
+    txt: 'text/plain',
+    html: 'text/html',
+    rtf: 'application/rtf',
+    odt: 'application/vnd.oasis.opendocument.text',
+    epub: 'application/epub+zip',
+  },
+  'application/vnd.google-apps.spreadsheet': {
+    xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    csv: 'text/csv',
+    pdf: 'application/pdf',
+    ods: 'application/vnd.oasis.opendocument.spreadsheet',
+    tsv: 'text/tab-separated-values',
+    html: 'text/html',
+  },
+  'application/vnd.google-apps.presentation': {
+    pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    pdf: 'application/pdf',
+    txt: 'text/plain',
+    odp: 'application/vnd.oasis.opendocument.presentation',
+  },
+  'application/vnd.google-apps.drawing': {
+    png: 'image/png',
+    svg: 'image/svg+xml',
+    pdf: 'application/pdf',
+    jpg: 'image/jpeg',
+  },
+};
+
+export const GOOGLE_WORKSPACE_DEFAULT_EXPORT: Record<string, { mimeType: string; ext: string }> = {
+  'application/vnd.google-apps.document': { mimeType: 'application/pdf', ext: '.pdf' },
+  'application/vnd.google-apps.spreadsheet': { mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', ext: '.xlsx' },
+  'application/vnd.google-apps.presentation': { mimeType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation', ext: '.pptx' },
+  'application/vnd.google-apps.drawing': { mimeType: 'image/png', ext: '.png' },
+};
+
+export type DownloadFileArgs = {
+  fileId: string;
+  localPath: string;
+  exportMimeType?: string;
+  overwrite?: boolean;
+};
+
+export type DownloadFileResult = {
+  driveName: string;
+  driveMimeType: string;
+  exportMime?: string;
+  isWorkspaceFile: boolean;
+  resolvedPath: string;
+  size: number;
+};
+
+type DriveGetParams = {
+  fileId: string;
+  fields?: string;
+  supportsAllDrives?: boolean;
+  alt?: 'media';
+};
+
+type DriveExportParams = {
+  fileId: string;
+  mimeType?: string;
+};
+
+type DriveRequestOptions = {
+  responseType?: 'stream';
+};
+
+type DriveResponse = {
+  data: any;
+};
+
+type DriveLike = {
+  files: {
+    get: (params: DriveGetParams, options?: DriveRequestOptions) => Promise<DriveResponse>;
+    export: (params: DriveExportParams, options?: DriveRequestOptions) => Promise<DriveResponse>;
+  };
+};
+
+function sanitizeDriveFilename(driveName: string): string {
+  return basename(driveName).replace(/^\.+/, '') || 'download';
+}
+
+function isPathWithinDirectory(targetPath: string, directoryPath: string): boolean {
+  const relativePath = relative(resolve(directoryPath), resolve(targetPath));
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+function resolveWorkspaceExport(
+  driveMimeType: string,
+  args: DownloadFileArgs,
+  resolvedPath: string,
+  isDirectory: boolean,
+): { exportMime: string; fileExtForName: string } {
+  const formatMap = GOOGLE_WORKSPACE_EXPORT_FORMATS[driveMimeType];
+  if (!formatMap) {
+    throw new Error(
+      `Unsupported Google Workspace type for export: ${driveMimeType}. ` +
+      'Supported types: Document, Spreadsheet, Presentation, Drawing.'
+    );
+  }
+
+  if (args.exportMimeType) {
+    const validMimes = Object.values(formatMap);
+    if (!validMimes.includes(args.exportMimeType)) {
+      throw new Error(
+        `Unsupported export format '${args.exportMimeType}' for ${driveMimeType}. ` +
+        `Supported: ${Object.entries(formatMap).map(([ext, mime]) => `${mime} (.${ext})`).join(', ')}`
+      );
+    }
+
+    const extForMime = Object.entries(formatMap).find(([, mime]) => mime === args.exportMimeType)?.[0] || 'bin';
+    return { exportMime: args.exportMimeType, fileExtForName: `.${extForMime}` };
+  }
+
+  if (!isDirectory && extname(resolvedPath)) {
+    const ext = extname(resolvedPath).slice(1).toLowerCase();
+    if (formatMap[ext]) {
+      return { exportMime: formatMap[ext], fileExtForName: `.${ext}` };
+    }
+  }
+
+  const defaultExport = GOOGLE_WORKSPACE_DEFAULT_EXPORT[driveMimeType];
+  return { exportMime: defaultExport.mimeType, fileExtForName: defaultExport.ext };
+}
+
+function buildTempPath(resolvedPath: string): string {
+  const random = Math.random().toString(16).slice(2);
+  return `${resolvedPath}.download-${Date.now()}-${random}.tmp`;
+}
+
+export async function downloadDriveFile(
+  drive: DriveLike,
+  args: DownloadFileArgs,
+  log: (message: string, data?: unknown) => void,
+): Promise<DownloadFileResult> {
+  if (!isAbsolute(args.localPath)) {
+    throw new Error('localPath must be an absolute path');
+  }
+
+  const normalizedLocalPath = resolve(args.localPath);
+
+  const fileMeta = await drive.files.get({
+    fileId: args.fileId,
+    fields: 'id, name, mimeType, size',
+    supportsAllDrives: true,
+  });
+
+  const driveMimeType = fileMeta.data.mimeType;
+  const driveName = fileMeta.data.name || 'download';
+
+  if (!driveMimeType) {
+    throw new Error('File has no MIME type');
+  }
+
+  const isWorkspaceFile = driveMimeType.startsWith('application/vnd.google-apps');
+  const overwrite = args.overwrite ?? false;
+
+  let resolvedPath = normalizedLocalPath;
+  let isDirectory = false;
+
+  if (existsSync(resolvedPath)) {
+    isDirectory = statSync(resolvedPath).isDirectory();
+  } else {
+    const parentDir = dirname(resolvedPath);
+    if (!existsSync(parentDir)) {
+      throw new Error(`Parent directory does not exist: ${parentDir}`);
+    }
+  }
+
+  let exportMime: string | undefined;
+  let fileExtForName = '';
+
+  if (isWorkspaceFile) {
+    const exportSelection = resolveWorkspaceExport(driveMimeType, args, resolvedPath, isDirectory);
+    exportMime = exportSelection.exportMime;
+    fileExtForName = exportSelection.fileExtForName;
+  }
+
+  if (isDirectory) {
+    const safeName = sanitizeDriveFilename(driveName);
+    let fileName = safeName;
+    if (isWorkspaceFile) {
+      const nameWithoutExt = safeName.replace(/\.[^.]+$/, '');
+      fileName = `${nameWithoutExt}${fileExtForName}`;
+    }
+
+    resolvedPath = join(resolvedPath, fileName);
+    if (!isPathWithinDirectory(resolvedPath, normalizedLocalPath)) {
+      throw new Error('Resolved file path escapes the target directory');
+    }
+  }
+
+  const targetExists = existsSync(resolvedPath);
+  if (targetExists && !overwrite) {
+    throw new Error(`File already exists at ${resolvedPath}. Set overwrite: true to replace it.`);
+  }
+
+  log('Downloading file', {
+    fileId: args.fileId,
+    driveName,
+    driveMimeType,
+    isWorkspaceFile,
+    exportMime,
+    localPath: resolvedPath,
+  });
+
+  const response = isWorkspaceFile
+    ? await drive.files.export({ fileId: args.fileId, mimeType: exportMime }, { responseType: 'stream' })
+    : await drive.files.get({ fileId: args.fileId, alt: 'media', supportsAllDrives: true }, { responseType: 'stream' });
+
+  const writePath = overwrite && targetExists ? buildTempPath(resolvedPath) : resolvedPath;
+  const dest = createWriteStream(writePath);
+
+  try {
+    await pipeline(response.data, dest);
+    if (writePath !== resolvedPath) {
+      renameSync(writePath, resolvedPath);
+    }
+  } catch (downloadErr) {
+    try {
+      unlinkSync(writePath);
+    } catch {
+      // Ignore cleanup errors.
+    }
+    throw downloadErr;
+  }
+
+  const finalStats = statSync(resolvedPath);
+
+  log('File downloaded successfully', {
+    fileId: args.fileId,
+    localPath: resolvedPath,
+    size: finalStats.size,
+  });
+
+  return {
+    driveName,
+    driveMimeType,
+    exportMime,
+    isWorkspaceFile,
+    resolvedPath,
+    size: finalStats.size,
+  };
+}

--- a/test/download-file.test.ts
+++ b/test/download-file.test.ts
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import test from 'node:test';
+
+import { downloadDriveFile } from '../src/download-file.js';
+
+type MockDriveOptions = {
+  mimeType: string;
+  name: string;
+  streamFactory?: () => Readable;
+};
+
+function createMockDrive(options: MockDriveOptions) {
+  const calls = {
+    metadataGetCount: 0,
+    mediaGetCount: 0,
+    exportCount: 0,
+    lastExportMime: undefined as string | undefined,
+  };
+
+  const drive = {
+    files: {
+      get: async (params: { alt?: string }) => {
+        if (params.alt === 'media') {
+          calls.mediaGetCount += 1;
+          return { data: options.streamFactory ? options.streamFactory() : Readable.from(['payload']) };
+        }
+
+        calls.metadataGetCount += 1;
+        return {
+          data: {
+            id: 'file-123',
+            name: options.name,
+            mimeType: options.mimeType,
+            size: '7',
+          },
+        };
+      },
+      export: async (params: { mimeType?: string }) => {
+        calls.exportCount += 1;
+        calls.lastExportMime = params.mimeType;
+        return { data: options.streamFactory ? options.streamFactory() : Readable.from(['payload']) };
+      },
+    },
+  };
+
+  return { drive, calls };
+}
+
+function createTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'download-file-test-'));
+}
+
+function createFailingStream(message: string): Readable {
+  let sent = false;
+  return new Readable({
+    read() {
+      if (!sent) {
+        sent = true;
+        this.push('partial-data');
+        this.destroy(new Error(message));
+      }
+    },
+  });
+}
+
+test('rejects relative localPath before hitting Drive API', async () => {
+  const { drive, calls } = createMockDrive({
+    mimeType: 'text/plain',
+    name: 'note.txt',
+  });
+
+  await assert.rejects(
+    () => downloadDriveFile(drive, { fileId: 'file-123', localPath: 'relative/path.txt' }, () => {}),
+    /absolute path/
+  );
+
+  assert.equal(calls.metadataGetCount, 0);
+});
+
+test('sanitizes malicious Drive filename when localPath is a directory', async () => {
+  const tempDir = createTempDir();
+  try {
+    const { drive } = createMockDrive({
+      mimeType: 'text/plain',
+      name: '../../etc/passwd',
+    });
+
+    const result = await downloadDriveFile(
+      drive,
+      { fileId: 'file-123', localPath: tempDir },
+      () => {}
+    );
+
+    const expectedPath = join(tempDir, 'passwd');
+    assert.equal(result.resolvedPath, expectedPath);
+    assert.equal(readFileSync(expectedPath, 'utf8'), 'payload');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('uses extension-based export MIME for Workspace files', async () => {
+  const tempDir = createTempDir();
+  try {
+    const outputPath = join(tempDir, 'sheet.csv');
+    const { drive, calls } = createMockDrive({
+      mimeType: 'application/vnd.google-apps.spreadsheet',
+      name: 'Quarterly Plan',
+    });
+
+    const result = await downloadDriveFile(
+      drive,
+      { fileId: 'file-123', localPath: outputPath },
+      () => {}
+    );
+
+    assert.equal(calls.exportCount, 1);
+    assert.equal(calls.mediaGetCount, 0);
+    assert.equal(calls.lastExportMime, 'text/csv');
+    assert.equal(result.exportMime, 'text/csv');
+    assert.equal(readFileSync(outputPath, 'utf8'), 'payload');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('returns an error when overwrite is false and target file exists', async () => {
+  const tempDir = createTempDir();
+  try {
+    const outputPath = join(tempDir, 'existing.txt');
+    writeFileSync(outputPath, 'original-content', 'utf8');
+
+    const { drive } = createMockDrive({
+      mimeType: 'text/plain',
+      name: 'ignored.txt',
+    });
+
+    await assert.rejects(
+      () =>
+        downloadDriveFile(
+          drive,
+          { fileId: 'file-123', localPath: outputPath, overwrite: false },
+          () => {}
+        ),
+      /already exists/
+    );
+
+    assert.equal(readFileSync(outputPath, 'utf8'), 'original-content');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('preserves original file on failed overwrite and removes temporary partial file', async () => {
+  const tempDir = createTempDir();
+  try {
+    const outputPath = join(tempDir, 'existing.txt');
+    writeFileSync(outputPath, 'original-content', 'utf8');
+
+    const { drive } = createMockDrive({
+      mimeType: 'text/plain',
+      name: 'existing.txt',
+      streamFactory: () => createFailingStream('network interrupted'),
+    });
+
+    await assert.rejects(
+      () =>
+        downloadDriveFile(
+          drive,
+          { fileId: 'file-123', localPath: outputPath, overwrite: true },
+          () => {}
+        ),
+      /network interrupted/
+    );
+
+    assert.equal(readFileSync(outputPath, 'utf8'), 'original-content');
+    const leftoverTmpFiles = readdirSync(tempDir).filter(
+      (name) => name.includes('.download-') && name.endsWith('.tmp')
+    );
+    assert.deepEqual(leftoverTmpFiles, []);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('replaces existing file when overwrite is true and download succeeds', async () => {
+  const tempDir = createTempDir();
+  try {
+    const outputPath = join(tempDir, 'existing.txt');
+    writeFileSync(outputPath, 'old-content', 'utf8');
+
+    const { drive } = createMockDrive({
+      mimeType: 'text/plain',
+      name: 'existing.txt',
+      streamFactory: () => Readable.from(['new-content']),
+    });
+
+    await downloadDriveFile(
+      drive,
+      { fileId: 'file-123', localPath: outputPath, overwrite: true },
+      () => {}
+    );
+
+    assert.equal(existsSync(outputPath), true);
+    assert.equal(readFileSync(outputPath, 'utf8'), 'new-content');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./.tmp-test",
+    "rootDir": "."
+  },
+  "include": [
+    "src/download-file.ts",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    ".tmp-test"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a `downloadFile` MCP tool — the reverse of the existing `uploadFile`. Streams Google Drive files directly to the local filesystem with proper backpressure handling (no memory buffering).

### Features
- **Google Workspace files** (Docs, Sheets, Slides, Drawings) are exported via `files.export` with configurable format
- **Regular files** are downloaded as-is via `files.get` with `alt: media`
- **Smart path resolution**: pass a directory and the filename is auto-resolved from Drive metadata
- **Format detection priority**: explicit `exportMimeType` > file extension inference > sensible defaults
- **Overwrite guard**: `overwrite: false` by default prevents accidental overwrites
- **Returns metadata only** (path, size, format) — never loads file content into LLM context

### Default Export Formats
| Workspace Type | Default |
|---|---|
| Docs | PDF |
| Sheets | XLSX |
| Slides | PPTX |
| Drawings | PNG |

### Parameters
| Parameter | Required | Description |
|---|---|---|
| `fileId` | Yes | Google Drive file ID |
| `localPath` | Yes | Absolute local path (file or directory) |
| `exportMimeType` | No | Export MIME type for Workspace files (auto-detected if omitted) |
| `overwrite` | No | Allow overwriting existing files (default: false) |

## Implementation

All changes are in `src/index.ts`:
1. **Imports**: Added `createWriteStream`, `extname`, `pipeline` from `stream/promises`
2. **Constants**: `GOOGLE_WORKSPACE_EXPORT_FORMATS` and `GOOGLE_WORKSPACE_DEFAULT_EXPORT` lookup tables
3. **Schema**: `DownloadFileSchema` (Zod validation)
4. **Tool registration**: Added to `ListToolsRequestSchema` handler
5. **Handler**: `case "downloadFile"` in `CallToolRequestSchema` handler

No new dependencies required — uses Node.js built-ins and the existing `googleapis` client.

## Testing

- Verified build passes (`npm run build`)
- Smoke tested: CSV export of a Google Sheet (correct content, correct size)
- Overwrite guard: returns error when file exists and `overwrite: false`
- Directory path: auto-resolves filename from Drive metadata
- End-to-end via Claude Code MCP: upload → download → verify content match → delete