### PR TITLE
fix: bump @modelcontextprotocol/sdk to ^1.24.0 (CVE-2025-66414)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     },
     "dependencies": {
         "@google-cloud/local-auth": "^3.0.1",
-        "@modelcontextprotocol/sdk": "1.16.0",
+        "@modelcontextprotocol/sdk": "^1.24.0",
         "@types/express": "^5.0.3",
         "express": "^5.1.0",
         "google-auth-library": "^9.15.0",


### PR DESCRIPTION
## Summary

Bumps `@modelcontextprotocol/sdk` from `1.16.0` to `^1.24.0` to address a known security vulnerability.

## Vulnerability

**CVE-2025-66414** — The MCP TypeScript SDK prior to v1.24.0 does not enable DNS rebinding protection by default for HTTP-based servers. When running on localhost without authentication, a malicious website could exploit DNS rebinding to bypass same-origin policy and invoke tools or access resources on behalf of the user.

- **Advisory:** [GHSA-w48q-cv73-mx4w](https://github.com/modelcontextprotocol/typescript-sdk/security/advisories/GHSA-w48q-cv73-mx4w)
- **Fix commit:** [modelcontextprotocol/typescript-sdk#1205](https://github.com/modelcontextprotocol/typescript-sdk/pull/1205)
- **Fixed in:** SDK v1.24.0+

## Changes

- `package.json`: `"@modelcontextprotocol/sdk": "1.16.0"` → `"@modelcontextprotocol/sdk": "^1.24.0"`

Uses caret (`^`) to allow compatible minor/patch updates while ensuring the security floor.

## Testing

This is a dependency version bump only. The SDK maintains backward compatibility for the APIs used by this project.