### PR TITLE
fix: add NODE_AUTH_TOKEN to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,3 +41,5 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `NODE_AUTH_TOKEN` env var to the npm publish step in the GitHub Actions workflow
- Without this, `npm publish` fails to authenticate with the npm registry, even when using OIDC trusted publishing with provenance

## Test plan
- [ ] Verify `NPM_TOKEN` secret is configured in repo settings
- [ ] Trigger a release and confirm publish succeeds