### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary
- Bump package.json version to 1.3.1 to match the GitHub release tag

## Test plan
- [ ] CI passes
- [ ] Merge and verify publish workflow succeeds on release trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)