### PR TITLE
chore: release 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary
Bump version to 1.3.2.

### Changes since 1.3.1
- **fix:** remove non-standard `optional` keyword from tool JSON schemas (#38)
- **feat:** configurable OAuth scopes via `GOOGLE_DRIVE_MCP_SCOPES` env var (#39)
- **feat:** add `listSharedDrives` tool (#40)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 146/146 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)