### PR TITLE
chore: bump version to 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary
- Bump version to 1.3.3

### Changes since v1.3.2

- **fix(docs):** support multi-tab documents in `readGoogleDoc` (#48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)