### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.3.3",
+    "version": "1.4.0",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary
- Bump version to 1.4.0

### Changes since v1.3.3

- **feat:** docs formatting aliases, find/replace, and sharing permission tools (#44)
- **feat:** make shareFile idempotent by updating existing user permission
- **feat:** add shareFile no-op path, removePermission by email, and find/replace dry-run
- **fix(docs):** support multi-tab documents in readGoogleDoc (#48)
- **docs:** document v1.4.0 docs aliases and drive permissions tools in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)