### PR TITLE
feat(v1.8): add Drive delta sync tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,25 @@ Add the server to your Claude Desktop configuration:
   - `driveId`: Optional shared drive ID
   - `includeRemoved`: Include removed items (optional, default true)
 
+#### Push channels (webhooks)
+- **watchFiles** - Start push notifications for a specific file
+  - `fileId`: File ID to watch
+  - `address`: Webhook callback URL
+  - `id`: Optional channel ID
+  - `token`: Optional opaque token echoed by Drive
+  - `expirationMs`: Optional channel expiration epoch millis
+
+- **watchChanges** - Start push notifications for Drive changes feed
+  - `pageToken`: Start token for change feed
+  - `address`: Webhook callback URL
+  - `id`: Optional channel ID
+  - `token`: Optional opaque token echoed by Drive
+  - `expirationMs`: Optional channel expiration epoch millis
+
+- **stopChannel** - Stop active push notification channel
+  - `id`: Channel ID
+  - `resourceId`: Resource ID from watch response
+
 - **uploadFile** - Upload a local file (any type: image, audio, video, PDF, etc.) to Google Drive
   - `localPath`: Absolute path to the local file
   - `name`: File name in Drive (optional, defaults to local filename)

--- a/test/helpers/mock-google-apis.ts
+++ b/test/helpers/mock-google-apis.ts
@@ -58,10 +58,15 @@ export function createDriveMock() {
     delete: stub(tracker, 'files.delete', {}),
     copy: stub(tracker, 'files.copy', { id: 'file-copy-1', name: 'Copy of test-file', webViewLink: 'https://link' }),
     export: stub(tracker, 'files.export', {}),
+    watch: stub(tracker, 'files.watch', { id: 'ch-file-1', resourceId: 'res-file-1', expiration: '9999999999999' }),
   };
   const changes = {
     getStartPageToken: stub(tracker, 'changes.getStartPageToken', { startPageToken: 'token-1' }),
     list: stub(tracker, 'changes.list', { changes: [], nextPageToken: 'token-2' }),
+    watch: stub(tracker, 'changes.watch', { id: 'ch-1', resourceId: 'res-1', expiration: '9999999999999' }),
+  };
+  const channels = {
+    stop: stub(tracker, 'channels.stop', {}),
   };
   const comments = {
     list: stub(tracker, 'comments.list', { comments: [] }),
@@ -82,7 +87,7 @@ export function createDriveMock() {
     delete: stub(tracker, 'permissions.delete', {}),
     get: stub(tracker, 'permissions.get', { id: 'perm-1', role: 'reader', emailAddress: 'user@example.com', type: 'user' }),
   };
-  return { service: { files, comments, replies, permissions, changes, drives }, tracker };
+  return { service: { files, comments, replies, permissions, changes, channels, drives }, tracker };
 }
 
 // ---------------------------------------------------------------------------

--- a/test/integration/drive.test.ts
+++ b/test/integration/drive.test.ts
@@ -311,6 +311,36 @@ describe('Drive tools', () => {
     });
   });
 
+  // --- watch channels ---
+  describe('watch channels', () => {
+    it('watchFiles happy path', async () => {
+      const res = await callTool(ctx.client, 'watchFiles', {
+        fileId: 'file-1',
+        address: 'https://example.com/webhook',
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Watch channel created'));
+    });
+
+    it('watchChanges happy path', async () => {
+      const res = await callTool(ctx.client, 'watchChanges', {
+        pageToken: 'token-1',
+        address: 'https://example.com/webhook',
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Changes watch channel created'));
+    });
+
+    it('stopChannel happy path', async () => {
+      const res = await callTool(ctx.client, 'stopChannel', {
+        id: 'ch-1',
+        resourceId: 'res-1',
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Stopped channel'));
+    });
+  });
+
   // --- moveItem ---
   describe('moveItem', () => {
     it('happy path', async () => {

--- a/test/schema/tool-registry.test.ts
+++ b/test/schema/tool-registry.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
 import { setupTestServer, type TestContext } from '../helpers/setup-server.js';
 
-const EXPECTED_TOOL_COUNT = 72;
+const EXPECTED_TOOL_COUNT = 75;
 
 const EXPECTED_TOOLS = [
   'search', 'createTextFile', 'updateTextFile', 'createFolder', 'listFolder', 'listSharedDrives',
@@ -21,7 +21,7 @@ const EXPECTED_TOOLS = [
   'styleGoogleSlidesShape', 'setGoogleSlidesBackground',
   'createGoogleSlidesTextBox', 'createGoogleSlidesShape',
   'getGoogleSlidesSpeakerNotes', 'updateGoogleSlidesSpeakerNotes',
-  'uploadFile', 'downloadFile', 'listPermissions', 'addPermission', 'updatePermission', 'removePermission', 'shareFile', 'getStartPageToken', 'listChanges',
+  'uploadFile', 'downloadFile', 'listPermissions', 'addPermission', 'updatePermission', 'removePermission', 'shareFile', 'getStartPageToken', 'listChanges', 'watchFiles', 'watchChanges', 'stopChannel',
   'listCalendars', 'getCalendarEvents', 'getCalendarEvent',
   'createCalendarEvent', 'updateCalendarEvent', 'deleteCalendarEvent',
   'insertTable', 'editTableCell', 'insertImageFromUrl', 'insertLocalImage',


### PR DESCRIPTION
## Summary
Starts v1.8.0 roadmap implementation with Drive delta sync primitives:
- `getStartPageToken`
- `listChanges`

## Features
- **getStartPageToken**
  - Supports optional `driveId` for shared drives.
- **listChanges**
  - Polls changes from a `pageToken`
  - Supports optional `driveId`, `pageSize`, `includeRemoved`
  - Returns `nextPageToken` and `newStartPageToken` when available
  - Includes useful text summaries for removed + updated files

## Tests
- Added integration tests for:
  - `getStartPageToken` happy path
  - `listChanges` happy path
  - `listChanges` validation error
- Extended Drive mock with `changes.getStartPageToken` and `changes.list`
- Updated tool-registry expected count + names

## Docs
- README updated with a new **Change polling (delta sync)** section.

## Validation
- `npm test -- --runInBand`
