### PR TITLE
chore: release v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.3.1",
+    "version": "1.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "1.3.1",
+            "version": "1.5.0",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary
- Bump version to 1.5.0
- Includes all changes since v1.4.0 (sheets+slides operator pack, listPermissions inherited marker fix)

### Changes since v1.4.0

**Sheets — tab lifecycle & governance**
- `addSheet` (alias for `addSpreadsheetSheet`), `listSheets`, `renameSheet`, `deleteSheet`
- `addDataValidation`, `protectRange`, `addNamedRange`

**Slides — lifecycle & templating**
- `deleteGoogleSlide`, `duplicateSlide`, `reorderSlides`
- `replaceAllTextInSlides`, `exportSlideThumbnail`

**Fixes**
- `resolveGridRange` helper extracted to reduce boilerplate in sheets handlers
- `addDataValidation` now requires `values` for all condition types
- `insertionIndex` schema enforces integer
- `listPermissions` shows inherited marker
- README docs corrected for `exportSlideThumbnail`

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 180 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)