### PR TITLE
chore: release v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Release v1.6.0 — Ingestion & Transformation Pack

Bumps version to 1.6.0. All features were merged in PR #46.

### New Tools (7)

**PDF Ingestion & Conversion**
- **convertPdfToGoogleDoc** — Convert a PDF in Drive into an editable Google Doc
- **bulkConvertFolderPdfs** — Batch-convert all PDFs in a folder with per-file reporting
- **uploadPdfWithSplit** — Upload a local PDF, optionally splitting into chunked parts via `pdf-lib`

**Docs Transformation Helpers**
- **addDocumentTab** — Add a new tab to a Google Doc
- **renameDocumentTab** — Rename an existing tab
- **insertSmartChip** — Insert a person mention at a given index
- **readSmartChips** — Read person mentions and rich links from a document

### Changelog

- Added `pdf-lib` production dependency for PDF page splitting
- Tool count: 82 → 89
- 188 tests, 0 failures