### PR TITLE
fix(search): add corpora=allDrives for Shared Drive results

### DIFF
--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -482,6 +482,7 @@ export async function handleTool(
         pageSize: Math.min(pageSize || 50, 100),
         pageToken: pageToken,
         fields: "nextPageToken, files(id, name, mimeType, modifiedTime, size)",
+        corpora: "allDrives",
         includeItemsFromAllDrives: true,
         supportsAllDrives: true
       });

--- a/test/integration/drive.test.ts
+++ b/test/integration/drive.test.ts
@@ -31,6 +31,20 @@ describe('Drive tools', () => {
       assert.equal(res.isError, true);
     });
 
+    it('passes corpora=allDrives to include shared drives', async () => {
+      ctx.mocks.drive.service.files.list._setImpl(async () => ({
+        data: { files: [{ id: 'f1', name: 'SharedFile.txt', mimeType: 'text/plain' }] },
+      }));
+      await callTool(ctx.client, 'search', { query: 'shared' });
+
+      const listCalls = ctx.mocks.drive.tracker.getCalls('files.list');
+      assert.ok(listCalls.length >= 1);
+      const args = listCalls[listCalls.length - 1].args[0];
+      assert.equal(args.corpora, 'allDrives');
+      assert.equal(args.includeItemsFromAllDrives, true);
+      assert.equal(args.supportsAllDrives, true);
+    });
+
     it('propagates API error', async () => {
       ctx.mocks.drive.service.files.list._setImpl(async () => { throw new Error('API quota exceeded'); });
       const res = await callTool(ctx.client, 'search', { query: 'test' });


### PR DESCRIPTION
## Summary
- Adds `corpora: "allDrives"` to the `files.list` call in the `search` tool so it returns results from Shared Drives, not just My Drive
- Adds unit test verifying the correct API parameters are passed

Fixes #55

## Test plan
- [x] `npm test` passes (189/189)
- [x] Manual: `search query="test"` returns files from Shared Drives
- [x] Manual: `search query="test" pageSize=5` — pagination still works
- [x] Manual: `listFolder` on a Shared Drive folder — no regression