### PR TITLE
chore: release 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary
- Bump version from 1.6.0 to 1.6.1
- Includes fix from #55: `corpora=allDrives` for Shared Drive search results

## Test plan
- [x] `npm test` passes
- [x] Verify published package version is 1.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)