### PR TITLE
fix(v1.7): address PR #52 review — stream response, try/catch, nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,11 +400,11 @@ Add the server to your Claude Desktop configuration:
   - `confirm`: Must be `true` to execute restore
 
 #### Auth Diagnostics & Scope Presets
-- **auth_getStatus** - Show token/scopes/auth health diagnostics (machine + human readable)
-- **auth_listScopes** - Show configured/requested scopes, granted scopes, missing scopes, and presets
-- **auth_testFileAccess** - Test Drive access (optionally against a specific `fileId`)
-- **auth_clearTokens** - Clear saved OAuth tokens (`confirm=true` required)
-- **auth_suggestScopePreset** - Get scope configuration instructions for a preset
+- **authGetStatus** - Show token/scopes/auth health diagnostics (machine + human readable)
+- **authListScopes** - Show configured/requested scopes, granted scopes, missing scopes, and presets
+- **authTestFileAccess** - Test Drive access (optionally against a specific `fileId`)
+- **authClearTokens** - Clear saved OAuth tokens (`confirm=true` required)
+- **authSuggestScopePreset** - Get scope configuration instructions for a preset
   - `preset`: `readonly` | `content-editor` | `full`
   - `clearTokens`: optional best-effort token clear
 

--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -19,7 +19,7 @@ export const SCOPE_PRESETS: Record<string, string[]> = {
   full: ['drive', 'documents', 'spreadsheets', 'presentations', 'calendar', 'calendar.events'],
 };
 
-export const DEFAULT_SCOPES: string[] = [
+export const DEFAULT_SCOPES: readonly string[] = [
   'drive', 'drive.file', 'drive.readonly',
   'documents', 'spreadsheets', 'presentations',
   'calendar', 'calendar.events',


### PR DESCRIPTION
## Summary
- Add `responseType: 'stream'` to workspace export fetch to prevent binary corruption of office formats (docx/xlsx/pptx)
- Wrap `restoreRevision` body in try/catch for consistent error handling with other destructive handlers
- Fix README auth tool names from underscore (`auth_getStatus`) to camelCase (`authGetStatus`)
- Make `DEFAULT_SCOPES` readonly
- Add error variable to bare `catch` clause for linter compliance

## Test plan
- [x] All 200 tests pass (`npm test -- --runInBand`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)