### PR TITLE
fix: remove authClearTokens and authSuggestScopePreset tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,14 +400,10 @@ Add the server to your Claude Desktop configuration:
   - `revisionId`: Revision ID to restore
   - `confirm`: Must be `true` to execute restore
 
-#### Auth Diagnostics & Scope Presets (v1.7.0)
+#### Auth Diagnostics (v1.7.0)
 - **authGetStatus** - Show token/scopes/auth health diagnostics (machine + human readable)
 - **authListScopes** - Show configured/requested scopes, granted scopes, missing scopes, and presets
 - **authTestFileAccess** - Test Drive access (optionally against a specific `fileId`)
-- **authClearTokens** - Clear saved OAuth tokens (`confirm=true` required)
-- **authSuggestScopePreset** - Get scope configuration instructions for a preset
-  - `preset`: `readonly` | `content-editor` | `full`
-  - `clearTokens`: optional best-effort token clear
 
 - **uploadFile** - Upload a local file (any type: image, audio, video, PDF, etc.) to Google Drive
   - `localPath`: Absolute path to the local file

--- a/test/integration/drive.test.ts
+++ b/test/integration/drive.test.ts
@@ -318,12 +318,6 @@ describe('Drive tools', () => {
       assert.ok(res.content[0].text.includes('Auth access check OK'));
     });
 
-    it('authClearTokens requires confirmation', async () => {
-      const res = await callTool(ctx.client, 'authClearTokens', {});
-      assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('confirm=true'));
-    });
-
     it('authTestFileAccess with specific fileId', async () => {
       ctx.mocks.drive.service.files.get._setImpl(async () => ({
         data: { id: 'file-1', name: 'TestDoc', mimeType: 'application/vnd.google-apps.document' },
@@ -333,17 +327,6 @@ describe('Drive tools', () => {
       assert.ok(res.content[0].text.includes('"mode":"file"') || res.content[0].text.includes('"mode": "file"'));
     });
 
-    it('authClearTokens with confirm=true clears tokens', async () => {
-      const res = await callTool(ctx.client, 'authClearTokens', { confirm: true });
-      assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Tokens cleared'));
-    });
-
-    it('authSuggestScopePreset returns deterministic instructions', async () => {
-      const res = await callTool(ctx.client, 'authSuggestScopePreset', { preset: 'readonly' });
-      assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('GOOGLE_DRIVE_MCP_SCOPES=drive.readonly'));
-    });
   });
 
   // --- revisions ---

--- a/test/schema/tool-registry.test.ts
+++ b/test/schema/tool-registry.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
 import { setupTestServer, type TestContext } from '../helpers/setup-server.js';
 
-const EXPECTED_TOOL_COUNT = 96;
+const EXPECTED_TOOL_COUNT = 94;
 
 const EXPECTED_TOOLS = [
   'search', 'createTextFile', 'updateTextFile', 'createFolder', 'listFolder', 'listSharedDrives',
@@ -21,7 +21,7 @@ const EXPECTED_TOOLS = [
   'styleGoogleSlidesShape', 'setGoogleSlidesBackground',
   'createGoogleSlidesTextBox', 'createGoogleSlidesShape',
   'getGoogleSlidesSpeakerNotes', 'updateGoogleSlidesSpeakerNotes', 'deleteGoogleSlide', 'duplicateSlide', 'reorderSlides', 'replaceAllTextInSlides', 'exportSlideThumbnail',
-  'uploadFile', 'downloadFile', 'listPermissions', 'addPermission', 'updatePermission', 'removePermission', 'shareFile', 'getRevisions', 'restoreRevision', 'authGetStatus', 'authListScopes', 'authTestFileAccess', 'authClearTokens', 'authSuggestScopePreset',
+  'uploadFile', 'downloadFile', 'listPermissions', 'addPermission', 'updatePermission', 'removePermission', 'shareFile', 'getRevisions', 'restoreRevision', 'authGetStatus', 'authListScopes', 'authTestFileAccess',
   'listCalendars', 'getCalendarEvents', 'getCalendarEvent',
   'createCalendarEvent', 'updateCalendarEvent', 'deleteCalendarEvent',
   'insertTable', 'editTableCell', 'insertImageFromUrl', 'insertLocalImage',


### PR DESCRIPTION
## Summary
- Remove `authClearTokens` tool — risky to expose to an LLM (model controls the `confirm` flag, can break the session by clearing tokens)
- Remove `authSuggestScopePreset` tool — poor MCP UX (returns text instructions it can't act on, has a surprising destructive `clearTokens` side effect in an "advisory" tool)

Keeps `authGetStatus`, `authListScopes`, and `authTestFileAccess` which provide read-only diagnostics.

## Changes
- `src/tools/drive.ts`: Remove Zod schemas, tool definitions, and handler cases; remove unused `unlink` import
- `README.md`: Remove tool entries, rename section header from "Auth Diagnostics & Scope Presets" to "Auth Diagnostics"
- `test/integration/drive.test.ts`: Remove 3 test cases
- `test/schema/tool-registry.test.ts`: Update expected count (96 → 94) and tool list

## Test plan
- [x] `npm test -- --runInBand` passes (197 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)