### PR TITLE
fix(ci): sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.4.0",
+    "version": "1.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "1.4.0",
+            "version": "1.7.1",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",
@@ -16,6 +16,7 @@
                 "google-auth-library": "^9.15.0",
                 "googleapis": "^144.0.0",
                 "open": "^10.2.0",
+                "pdf-lib": "^1.17.1",
                 "punycode": "^2.3.1",
                 "uuid": "^11.0.3",
                 "zod": "^3.25.76"
@@ -899,6 +900,24 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@pdf-lib/standard-fonts": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+            "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^1.0.6"
+            }
+        },
+        "node_modules/@pdf-lib/upng": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+            "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^1.0.10"
             }
         },
         "node_modules/@types/body-parser": {
@@ -3392,6 +3411,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3448,6 +3473,18 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/pdf-lib": {
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+            "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+            "license": "MIT",
+            "dependencies": {
+                "@pdf-lib/standard-fonts": "^1.0.0",
+                "@pdf-lib/upng": "^1.0.1",
+                "pako": "^1.0.11",
+                "tslib": "^1.11.1"
             }
         },
         "node_modules/picomatch": {
@@ -4065,6 +4102,12 @@
             "peerDependencies": {
                 "typescript": ">=4.8.4"
             }
+        },
+        "node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",


### PR DESCRIPTION
## Summary
- Add missing `pdf-lib` and its transitive dependencies (`@pdf-lib/standard-fonts`, `@pdf-lib/upng`, `pako`, `tslib`) to `package-lock.json`
- Fixes `npm ci` failure in CI caused by lock file being out of sync after the recent merge

## Test plan
- [ ] Verify CI passes with the updated lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)