### PR TITLE
chore: release v1.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "1.7.1",
+            "version": "1.7.2",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary
- Sync `package-lock.json` with `package.json` (adds missing `pdf-lib` and transitive deps)
- Bump version to 1.7.2

### Changes since v1.7.1
- **fix(ci):** sync package-lock.json with package.json
- **fix(sheets):** define nested items for appendSpreadsheetRows values schema
- **feat(drive):** add convertToGoogleFormat param to uploadFile for native Google Workspace conversion
- **fix:** address PR review feedback on bulletize and uploadFile
- **refactor(drive):** simplify and fix code quality issues

## Test plan
- [ ] CI passes (npm ci + build + tests)
- [ ] Merge to master, tag `v1.7.2`, and publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)