### PR TITLE
fix: use correct API field name for tab creation

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2904,8 +2904,8 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
       await docs.documents.batchUpdate({
         documentId: a.documentId,
-        // createTab is not yet in the googleapis TypeScript types — cast required
-        requestBody: { requests: [{ createTab: { tabProperties: { title: a.title } } } as any] }
+        // addDocumentTab is not yet in the googleapis TypeScript types — cast required
+        requestBody: { requests: [{ addDocumentTab: { tabProperties: { title: a.title } } } as any] }
       });
 
       return { content: [{ type: 'text', text: `Requested creation of tab "${a.title}" in document ${a.documentId}.` }], isError: false };


### PR DESCRIPTION
## Summary
- The `addDocumentTab` tool handler used `createTab` as the batchUpdate request field name, which is not a valid Google Docs API v1 request type
- Changed to `addDocumentTab` which is the correct field name per the [official API reference](https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/request)
- This fixes the runtime error: `Invalid JSON payload received. Unknown name "createTab" at 'requests[0]': Cannot find field.`

## Test plan
- [x] All 211 existing tests pass
- [ ] Manual test: call `addDocumentTab` against a real Google Doc and verify a tab is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)