### PR TITLE
fix: use correct API field name for tab properties update

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -3032,8 +3032,8 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
       await docs.documents.batchUpdate({
         documentId: a.documentId,
-        // updateTabProperties is not yet in the googleapis TypeScript types — cast required
-        requestBody: { requests: [{ updateTabProperties: { tabId: a.tabId, tabProperties: { title: a.title }, fields: 'title' } } as any] }
+        // updateDocumentTabProperties is not yet in the googleapis TypeScript types — cast required
+        requestBody: { requests: [{ updateDocumentTabProperties: { tabId: a.tabId, tabProperties: { title: a.title }, fields: 'title' } } as any] }
       });
 
       return { content: [{ type: 'text', text: `Renamed tab ${a.tabId} to "${a.title}".` }], isError: false };


### PR DESCRIPTION
## Summary
- The `renameDocumentTab` tool handler used `updateTabProperties` as the batchUpdate request field name, which is not a valid Google Docs API v1 request type
- Changed to `updateDocumentTabProperties` which is the correct field name per the [official API reference](https://developers.google.com/docs/api/reference/rest/v1/documents/request)
- This is the same class of bug fixed in #92 (`createTab` → `addDocumentTab`) — the tab-related requests were consistently using shortened names instead of the official `*DocumentTab*` variants

## Test plan
- [x] All 268 existing tests pass
- [ ] Manual test: call `renameDocumentTab` against a real Google Doc and verify the tab is renamed

🤖 Generated with [Claude Code](https://claude.com/claude-code)