### PR TITLE
chore: release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.2](https://github.com/piotr-agier/google-drive-mcp/compare/v2.0.1...v2.0.2) (2026-04-04)
+
+### Bug Fixes
+
+- **docs:** use correct API field name for tab creation ([08caa89](https://github.com/piotr-agier/google-drive-mcp/commit/08caa89))
+- use correct API field name for tab properties update ([8a67c75](https://github.com/piotr-agier/google-drive-mcp/commit/8a67c75))
+
 ## [2.0.1](https://github.com/piotr-agier/google-drive-mcp/compare/v2.0.0...v2.0.1) (2026-04-01)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary

- Bump version to 2.0.2
- **fix(docs):** use correct API field name for tab creation
- **fix:** use correct API field name for tab properties update

## Test plan

- [ ] Verify CI passes
- [ ] Publish to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)