### PR TITLE
Add Slides element management tools

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod';
-import { createReadStream, existsSync } from 'fs';
-import { basename, extname } from 'path';
 import JSZip from 'jszip';
 import type { ToolDefinition, ToolContext, ToolResult } from '../types.js';
 import { errorResponse } from '../types.js';
 import { escapeDriveQuery } from '../utils.js';
+import { uploadImageToDrive } from '../utils/driveImageUpload.js';
 
 // ---------------------------------------------------------------------------
 // Helper functions
@@ -363,87 +362,7 @@ async function insertInlineImageHelper(
   return executeBatchUpdate(ctx, documentId, [request]);
 }
 
-// Upload a local image to Drive and return its URL
-async function uploadImageToDriveHelper(
-  ctx: ToolContext,
-  localFilePath: string,
-  parentFolderId?: string,
-  makePublic: boolean = false
-): Promise<string> {
-  // Verify file exists
-  if (!existsSync(localFilePath)) {
-    throw new Error(`Image file not found: ${localFilePath}`);
-  }
-
-  // Get file name and mime type
-  const fileName = basename(localFilePath);
-  const mimeTypeMap: { [key: string]: string } = {
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.png': 'image/png',
-    '.gif': 'image/gif',
-    '.bmp': 'image/bmp',
-    '.webp': 'image/webp',
-    '.svg': 'image/svg+xml'
-  };
-
-  const ext = extname(localFilePath).toLowerCase();
-  const mimeType = mimeTypeMap[ext] || 'application/octet-stream';
-
-  // Upload file to Drive
-  const fileMetadata: any = {
-    name: fileName,
-    mimeType: mimeType
-  };
-
-  if (parentFolderId) {
-    fileMetadata.parents = [parentFolderId];
-  }
-
-  const media = {
-    mimeType: mimeType,
-    body: createReadStream(localFilePath)
-  };
-
-  const drive = ctx.getDrive();
-
-  const uploadResponse = await drive.files.create({
-    requestBody: fileMetadata,
-    media: media,
-    fields: 'id,webViewLink,webContentLink',
-    supportsAllDrives: true
-  });
-
-  const fileId = uploadResponse.data.id;
-  if (!fileId) {
-    throw new Error('Failed to upload image to Drive - no file ID returned');
-  }
-
-  if (makePublic) {
-    // Make the file publicly readable so the Docs API can fetch it
-    await drive.permissions.create({
-      fileId: fileId,
-      requestBody: {
-        role: 'reader',
-        type: 'anyone'
-      }
-    });
-  }
-
-  // Get the webContentLink
-  const fileInfo = await drive.files.get({
-    fileId: fileId,
-    fields: 'webContentLink',
-    supportsAllDrives: true
-  });
-
-  const webContentLink = fileInfo.data.webContentLink;
-  if (!webContentLink) {
-    throw new Error('Failed to get web content link for uploaded image');
-  }
-
-  return webContentLink;
-}
+// Image upload moved to ../utils/driveImageUpload.ts.
 
 // ---------------------------------------------------------------------------
 // Comment context extraction helpers
@@ -2901,7 +2820,10 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       }
 
       // Upload the image to Drive
-      const imageUrl = await uploadImageToDriveHelper(ctx, a.localImagePath, parentFolderId, a.makePublic);
+      const { webContentLink: imageUrl } = await uploadImageToDrive(ctx, a.localImagePath, {
+        parentFolderId,
+        makePublic: a.makePublic,
+      });
 
       // Insert the image into the document
       await insertInlineImageHelper(ctx, a.documentId, imageUrl, a.index, a.width, a.height);

--- a/src/tools/slides.ts
+++ b/src/tools/slides.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
+import { existsSync } from 'fs';
+import { createReadStream } from 'fs';
+import { basename, extname } from 'path';
 import type { ToolDefinition, ToolResult, ToolContext } from '../types.js';
 import { errorResponse } from '../types.js';
 
@@ -153,6 +156,136 @@ const ExportSlideThumbnailSchema = z.object({
   mimeType: z.enum(["PNG", "JPEG"]).optional().default("PNG"),
   size: z.enum(["SMALL", "MEDIUM", "LARGE"]).optional().default("LARGE")
 });
+
+const InsertSlidesImageFromUrlSchema = z.object({
+  presentationId: z.string().min(1, "Presentation ID is required"),
+  pageObjectId: z.string().min(1, "Slide/page object ID is required"),
+  imageUrl: z.string().url("A valid image URL is required"),
+  x: z.number().optional().default(0),
+  y: z.number().optional().default(0),
+  width: z.number().optional(),
+  height: z.number().optional(),
+});
+
+const InsertSlidesLocalImageSchema = z.object({
+  presentationId: z.string().min(1, "Presentation ID is required"),
+  pageObjectId: z.string().min(1, "Slide/page object ID is required"),
+  localImagePath: z.string().min(1, "Local image path is required"),
+  x: z.number().optional().default(0),
+  y: z.number().optional().default(0),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  makePublic: z.boolean().optional().default(true),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function uploadImageToDriveForSlides(
+  ctx: ToolContext,
+  localFilePath: string,
+  makePublic: boolean = true
+): Promise<string> {
+  if (!existsSync(localFilePath)) {
+    throw new Error(`Image file not found: ${localFilePath}`);
+  }
+
+  const fileName = basename(localFilePath);
+  const mimeTypeMap: { [key: string]: string } = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.bmp': 'image/bmp',
+    '.webp': 'image/webp',
+    '.svg': 'image/svg+xml'
+  };
+
+  const ext = extname(localFilePath).toLowerCase();
+  const mimeType = mimeTypeMap[ext] || 'application/octet-stream';
+
+  const drive = ctx.getDrive();
+
+  const uploadResponse = await drive.files.create({
+    requestBody: { name: fileName, mimeType },
+    media: { mimeType, body: createReadStream(localFilePath) },
+    fields: 'id,webViewLink,webContentLink',
+    supportsAllDrives: true
+  });
+
+  const fileId = uploadResponse.data.id;
+  if (!fileId) throw new Error('Failed to upload image to Drive');
+
+  if (makePublic) {
+    await drive.permissions.create({
+      fileId,
+      requestBody: { role: 'reader', type: 'anyone' }
+    });
+  }
+
+  const fileInfo = await drive.files.get({
+    fileId,
+    fields: 'webContentLink',
+    supportsAllDrives: true
+  });
+
+  const webContentLink = fileInfo.data.webContentLink;
+  if (!webContentLink) throw new Error('Failed to get web content link for uploaded image');
+
+  return webContentLink;
+}
+
+async function insertImageIntoSlide(
+  ctx: ToolContext,
+  presentationId: string,
+  pageObjectId: string,
+  imageUrl: string,
+  x: number,
+  y: number,
+  width?: number,
+  height?: number,
+): Promise<ToolResult> {
+  const slidesService = ctx.google.slides({ version: 'v1', auth: ctx.authClient });
+  const objectId = `img_${uuidv4().substring(0, 8)}`;
+
+  const elementProperties: any = {
+    pageObjectId,
+  };
+
+  if (width != null && height != null) {
+    elementProperties.size = {
+      width: { magnitude: width, unit: 'EMU' },
+      height: { magnitude: height, unit: 'EMU' },
+    };
+  }
+
+  elementProperties.transform = {
+    scaleX: 1,
+    scaleY: 1,
+    translateX: x,
+    translateY: y,
+    unit: 'EMU',
+  };
+
+  await slidesService.presentations.batchUpdate({
+    presentationId,
+    requestBody: {
+      requests: [{
+        createImage: {
+          objectId,
+          url: imageUrl,
+          elementProperties,
+        }
+      }]
+    }
+  });
+
+  return {
+    content: [{ type: 'text', text: `Inserted image into slide ${pageObjectId} (objectId: ${objectId})` }],
+    isError: false,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Tool Definitions
@@ -470,6 +603,41 @@ export const toolDefinitions: ToolDefinition[] = [
         size: { type: "string", enum: ["SMALL", "MEDIUM", "LARGE"], description: "Thumbnail size" }
       },
       required: ["presentationId", "slideObjectId"]
+    }
+  },
+  {
+    name: "insertSlidesImageFromUrl",
+    description: "Insert an image into a Google Slides slide from a publicly accessible URL",
+    inputSchema: {
+      type: "object",
+      properties: {
+        presentationId: { type: "string", description: "Presentation ID" },
+        pageObjectId: { type: "string", description: "Slide/page object ID to insert the image into" },
+        imageUrl: { type: "string", description: "Publicly accessible URL of the image" },
+        x: { type: "number", description: "X position in EMU (default: 0)" },
+        y: { type: "number", description: "Y position in EMU (default: 0)" },
+        width: { type: "number", description: "Width in EMU (omit to auto-size)" },
+        height: { type: "number", description: "Height in EMU (omit to auto-size)" }
+      },
+      required: ["presentationId", "pageObjectId", "imageUrl"]
+    }
+  },
+  {
+    name: "insertSlidesLocalImage",
+    description: "Upload a local image file to Google Drive and insert it into a Google Slides slide",
+    inputSchema: {
+      type: "object",
+      properties: {
+        presentationId: { type: "string", description: "Presentation ID" },
+        pageObjectId: { type: "string", description: "Slide/page object ID to insert the image into" },
+        localImagePath: { type: "string", description: "Absolute path to the local image file" },
+        x: { type: "number", description: "X position in EMU (default: 0)" },
+        y: { type: "number", description: "Y position in EMU (default: 0)" },
+        width: { type: "number", description: "Width in EMU (omit to auto-size)" },
+        height: { type: "number", description: "Height in EMU (omit to auto-size)" },
+        makePublic: { type: "boolean", description: "Make uploaded image publicly accessible (default: true, required for Slides API to fetch it)" }
+      },
+      required: ["presentationId", "pageObjectId", "localImagePath"]
     }
   },
 ];
@@ -1480,6 +1648,21 @@ export async function handleTool(
         content: [{ type: 'text', text: `Slide thumbnail URL (${a.mimeType}, ${a.size}): ${url}` }],
         isError: false,
       };
+    }
+
+    case "insertSlidesImageFromUrl": {
+      const validation = InsertSlidesImageFromUrlSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+      return insertImageIntoSlide(ctx, a.presentationId, a.pageObjectId, a.imageUrl, a.x, a.y, a.width, a.height);
+    }
+
+    case "insertSlidesLocalImage": {
+      const validation = InsertSlidesLocalImageSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+      const imageUrl = await uploadImageToDriveForSlides(ctx, a.localImagePath, a.makePublic);
+      return insertImageIntoSlide(ctx, a.presentationId, a.pageObjectId, imageUrl, a.x, a.y, a.width, a.height);
     }
 
     default:

--- a/src/tools/slides.ts
+++ b/src/tools/slides.ts
@@ -167,6 +167,25 @@ const InsertSlidesImageFromUrlSchema = z.object({
   height: z.number().optional(),
 });
 
+const MoveSlideElementSchema = z.object({
+  presentationId: z.string().min(1, "Presentation ID is required"),
+  objectId: z.string().min(1, "Element object ID is required"),
+  x: z.number().optional(),
+  y: z.number().optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+});
+
+const DeleteSlideElementSchema = z.object({
+  presentationId: z.string().min(1, "Presentation ID is required"),
+  objectId: z.string().min(1, "Element object ID is required"),
+});
+
+const GetSlideElementInfoSchema = z.object({
+  presentationId: z.string().min(1, "Presentation ID is required"),
+  slideObjectId: z.string().optional(),
+});
+
 const InsertSlidesLocalImageSchema = z.object({
   presentationId: z.string().min(1, "Presentation ID is required"),
   pageObjectId: z.string().min(1, "Slide/page object ID is required"),
@@ -620,6 +639,46 @@ export const toolDefinitions: ToolDefinition[] = [
         height: { type: "number", description: "Height in EMU (omit to auto-size)" }
       },
       required: ["presentationId", "pageObjectId", "imageUrl"]
+    }
+  },
+  {
+    name: "getSlideElementInfo",
+    description: "Get position, size, and transform of all elements on a slide. Returns actual rendered bounds.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        presentationId: { type: "string", description: "Presentation ID" },
+        slideObjectId: { type: "string", description: "Slide object ID (omit to get all slides)" }
+      },
+      required: ["presentationId"]
+    }
+  },
+  {
+    name: "moveSlideElement",
+    description: "Move and/or resize an element (image, text box, shape) on a Google Slides slide",
+    inputSchema: {
+      type: "object",
+      properties: {
+        presentationId: { type: "string", description: "Presentation ID" },
+        objectId: { type: "string", description: "Element object ID to move/resize" },
+        x: { type: "number", description: "New X position in EMU" },
+        y: { type: "number", description: "New Y position in EMU" },
+        width: { type: "number", description: "New width in EMU" },
+        height: { type: "number", description: "New height in EMU" }
+      },
+      required: ["presentationId", "objectId"]
+    }
+  },
+  {
+    name: "deleteSlideElement",
+    description: "Delete an element (image, text box, shape) from a Google Slides slide",
+    inputSchema: {
+      type: "object",
+      properties: {
+        presentationId: { type: "string", description: "Presentation ID" },
+        objectId: { type: "string", description: "Element object ID to delete" }
+      },
+      required: ["presentationId", "objectId"]
     }
   },
   {
@@ -1646,6 +1705,135 @@ export async function handleTool(
 
       return {
         content: [{ type: 'text', text: `Slide thumbnail URL (${a.mimeType}, ${a.size}): ${url}` }],
+        isError: false,
+      };
+    }
+
+    case "getSlideElementInfo": {
+      const validation = GetSlideElementInfoSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+
+      const slidesService = ctx.google.slides({ version: 'v1', auth: ctx.authClient });
+      const pres = await slidesService.presentations.get({ presentationId: a.presentationId });
+      const slideWidth = pres.data.pageSize?.width?.magnitude || 9144000;
+      const slideHeight = pres.data.pageSize?.height?.magnitude || 6858000;
+
+      const lines: string[] = [`Slide dimensions: ${slideWidth} x ${slideHeight} EMU`];
+
+      for (const slide of pres.data.slides || []) {
+        if (a.slideObjectId && slide.objectId !== a.slideObjectId) continue;
+        lines.push(`\n--- Slide: ${slide.objectId} ---`);
+        for (const el of slide.pageElements || []) {
+          const t = el.transform || {};
+          const s = el.size || {};
+          const intrW = s.width?.magnitude || 0;
+          const intrH = s.height?.magnitude || 0;
+          const scX = t.scaleX || 1;
+          const scY = t.scaleY || 1;
+          const tx = t.translateX || 0;
+          const ty = t.translateY || 0;
+          const renderedW = intrW * scX;
+          const renderedH = intrH * scY;
+          const right = tx + renderedW;
+          const bottom = ty + renderedH;
+          const offPage = (right > slideWidth || bottom > slideHeight) ? ' *** OFF PAGE ***' : '';
+          lines.push(`  ${el.objectId} (${el.shape ? 'shape:' + el.shape.shapeType : el.image ? 'image' : 'other'})`);
+          lines.push(`    intrinsic: ${intrW} x ${intrH}, scale: ${scX} x ${scY}`);
+          lines.push(`    rendered: ${Math.round(renderedW)} x ${Math.round(renderedH)} at (${tx}, ${ty})`);
+          lines.push(`    bounds: right=${Math.round(right)}, bottom=${Math.round(bottom)}${offPage}`);
+        }
+      }
+
+      return { content: [{ type: 'text', text: lines.join('\n') }], isError: false };
+    }
+
+    case "moveSlideElement": {
+      const validation = MoveSlideElementSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+
+      const slidesService = ctx.google.slides({ version: 'v1', auth: ctx.authClient });
+
+      // First get the current element to read its existing transform and size
+      const pres = await slidesService.presentations.get({ presentationId: a.presentationId });
+      let currentTransform: any = null;
+      let currentSize: any = null;
+      for (const slide of pres.data.slides || []) {
+        for (const el of slide.pageElements || []) {
+          if (el.objectId === a.objectId) {
+            currentTransform = el.transform;
+            currentSize = el.size;
+            break;
+          }
+        }
+        if (currentTransform) break;
+      }
+
+      if (!currentTransform) {
+        return errorResponse(`Element ${a.objectId} not found in presentation`);
+      }
+
+      // Compute new scale factors if width/height provided
+      const origWidth = (currentSize?.width?.magnitude || 3000000);
+      const origHeight = (currentSize?.height?.magnitude || 3000000);
+      const curScaleX = currentTransform.scaleX || 1;
+      const curScaleY = currentTransform.scaleY || 1;
+
+      let newScaleX = curScaleX;
+      let newScaleY = curScaleY;
+      if (a.width !== undefined) {
+        newScaleX = a.width / origWidth;
+      }
+      if (a.height !== undefined) {
+        newScaleY = a.height / origHeight;
+      }
+
+      const newX = a.x ?? (currentTransform.translateX || 0);
+      const newY = a.y ?? (currentTransform.translateY || 0);
+
+      const requests: any[] = [{
+        updatePageElementTransform: {
+          objectId: a.objectId,
+          applyMode: 'ABSOLUTE',
+          transform: {
+            scaleX: newScaleX,
+            scaleY: newScaleY,
+            translateX: newX,
+            translateY: newY,
+            shearX: currentTransform.shearX || 0,
+            shearY: currentTransform.shearY || 0,
+            unit: 'EMU',
+          },
+        },
+      }];
+
+      await slidesService.presentations.batchUpdate({
+        presentationId: a.presentationId,
+        requestBody: { requests },
+      });
+
+      return {
+        content: [{ type: 'text', text: `Moved element ${a.objectId} to (${newX}, ${newY})` }],
+        isError: false,
+      };
+    }
+
+    case "deleteSlideElement": {
+      const validation = DeleteSlideElementSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+
+      const slidesService = ctx.google.slides({ version: 'v1', auth: ctx.authClient });
+      await slidesService.presentations.batchUpdate({
+        presentationId: a.presentationId,
+        requestBody: {
+          requests: [{ deleteObject: { objectId: a.objectId } }],
+        },
+      });
+
+      return {
+        content: [{ type: 'text', text: `Deleted element ${a.objectId}` }],
         isError: false,
       };
     }

--- a/src/tools/slides.ts
+++ b/src/tools/slides.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
-import { existsSync } from 'fs';
-import { createReadStream } from 'fs';
-import { basename, extname } from 'path';
+import type { slides_v1 } from 'googleapis';
 import type { ToolDefinition, ToolResult, ToolContext } from '../types.js';
 import { errorResponse } from '../types.js';
+import { uploadImageToDrive, deleteDriveFile } from '../utils/driveImageUpload.js';
 
 // ---------------------------------------------------------------------------
 // Zod Schemas
@@ -194,66 +193,11 @@ const InsertSlidesLocalImageSchema = z.object({
   y: z.number().optional().default(0),
   width: z.number().optional(),
   height: z.number().optional(),
-  makePublic: z.boolean().optional().default(true),
 });
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-async function uploadImageToDriveForSlides(
-  ctx: ToolContext,
-  localFilePath: string,
-  makePublic: boolean = true
-): Promise<string> {
-  if (!existsSync(localFilePath)) {
-    throw new Error(`Image file not found: ${localFilePath}`);
-  }
-
-  const fileName = basename(localFilePath);
-  const mimeTypeMap: { [key: string]: string } = {
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.png': 'image/png',
-    '.gif': 'image/gif',
-    '.bmp': 'image/bmp',
-    '.webp': 'image/webp',
-    '.svg': 'image/svg+xml'
-  };
-
-  const ext = extname(localFilePath).toLowerCase();
-  const mimeType = mimeTypeMap[ext] || 'application/octet-stream';
-
-  const drive = ctx.getDrive();
-
-  const uploadResponse = await drive.files.create({
-    requestBody: { name: fileName, mimeType },
-    media: { mimeType, body: createReadStream(localFilePath) },
-    fields: 'id,webViewLink,webContentLink',
-    supportsAllDrives: true
-  });
-
-  const fileId = uploadResponse.data.id;
-  if (!fileId) throw new Error('Failed to upload image to Drive');
-
-  if (makePublic) {
-    await drive.permissions.create({
-      fileId,
-      requestBody: { role: 'reader', type: 'anyone' }
-    });
-  }
-
-  const fileInfo = await drive.files.get({
-    fileId,
-    fields: 'webContentLink',
-    supportsAllDrives: true
-  });
-
-  const webContentLink = fileInfo.data.webContentLink;
-  if (!webContentLink) throw new Error('Failed to get web content link for uploaded image');
-
-  return webContentLink;
-}
 
 async function insertImageIntoSlide(
   ctx: ToolContext,
@@ -268,8 +212,15 @@ async function insertImageIntoSlide(
   const slidesService = ctx.google.slides({ version: 'v1', auth: ctx.authClient });
   const objectId = `img_${uuidv4().substring(0, 8)}`;
 
-  const elementProperties: any = {
+  const elementProperties: slides_v1.Schema$PageElementProperties = {
     pageObjectId,
+    transform: {
+      scaleX: 1,
+      scaleY: 1,
+      translateX: x,
+      translateY: y,
+      unit: 'EMU',
+    },
   };
 
   if (width != null && height != null) {
@@ -279,25 +230,13 @@ async function insertImageIntoSlide(
     };
   }
 
-  elementProperties.transform = {
-    scaleX: 1,
-    scaleY: 1,
-    translateX: x,
-    translateY: y,
-    unit: 'EMU',
-  };
-
   await slidesService.presentations.batchUpdate({
     presentationId,
     requestBody: {
       requests: [{
-        createImage: {
-          objectId,
-          url: imageUrl,
-          elementProperties,
-        }
-      }]
-    }
+        createImage: { objectId, url: imageUrl, elementProperties },
+      }],
+    },
   });
 
   return {
@@ -693,8 +632,7 @@ export const toolDefinitions: ToolDefinition[] = [
         x: { type: "number", description: "X position in EMU (default: 0)" },
         y: { type: "number", description: "Y position in EMU (default: 0)" },
         width: { type: "number", description: "Width in EMU (omit to auto-size)" },
-        height: { type: "number", description: "Height in EMU (omit to auto-size)" },
-        makePublic: { type: "boolean", description: "Make uploaded image publicly accessible (default: true, required for Slides API to fetch it)" }
+        height: { type: "number", description: "Height in EMU (omit to auto-size)" }
       },
       required: ["presentationId", "pageObjectId", "localImagePath"]
     }
@@ -1715,14 +1653,35 @@ export async function handleTool(
       const a = validation.data;
 
       const slidesService = ctx.google.slides({ version: 'v1', auth: ctx.authClient });
-      const pres = await slidesService.presentations.get({ presentationId: a.presentationId });
-      const slideWidth = pres.data.pageSize?.width?.magnitude || 9144000;
-      const slideHeight = pres.data.pageSize?.height?.magnitude || 6858000;
+
+      // Page size lives on the presentation; grab just that field.
+      const sizeOnly = await slidesService.presentations.get({
+        presentationId: a.presentationId,
+        fields: 'pageSize',
+      });
+      const slideWidth = sizeOnly.data.pageSize?.width?.magnitude || 9144000;
+      const slideHeight = sizeOnly.data.pageSize?.height?.magnitude || 6858000;
+
+      // If a specific slide is requested, fetch just that page. Otherwise fetch
+      // only the fields of the slides we actually render.
+      let slides: slides_v1.Schema$Page[] = [];
+      if (a.slideObjectId) {
+        const page = await slidesService.presentations.pages.get({
+          presentationId: a.presentationId,
+          pageObjectId: a.slideObjectId,
+          fields: 'objectId,pageElements(objectId,transform,size,shape/shapeType,image)',
+        });
+        slides = [page.data];
+      } else {
+        const withSlides = await slidesService.presentations.get({
+          presentationId: a.presentationId,
+          fields: 'slides(objectId,pageElements(objectId,transform,size,shape/shapeType,image))',
+        });
+        slides = withSlides.data.slides || [];
+      }
 
       const lines: string[] = [`Slide dimensions: ${slideWidth} x ${slideHeight} EMU`];
-
-      for (const slide of pres.data.slides || []) {
-        if (a.slideObjectId && slide.objectId !== a.slideObjectId) continue;
+      for (const slide of slides) {
         lines.push(`\n--- Slide: ${slide.objectId} ---`);
         for (const el of slide.pageElements || []) {
           const t = el.transform || {};
@@ -1737,7 +1696,8 @@ export async function handleTool(
           const renderedH = intrH * scY;
           const right = tx + renderedW;
           const bottom = ty + renderedH;
-          const offPage = (right > slideWidth || bottom > slideHeight) ? ' *** OFF PAGE ***' : '';
+          const offPage = (tx < 0 || ty < 0 || right > slideWidth || bottom > slideHeight)
+            ? ' *** OFF PAGE ***' : '';
           lines.push(`  ${el.objectId} (${el.shape ? 'shape:' + el.shape.shapeType : el.image ? 'image' : 'other'})`);
           lines.push(`    intrinsic: ${intrW} x ${intrH}, scale: ${scX} x ${scY}`);
           lines.push(`    rendered: ${Math.round(renderedW)} x ${Math.round(renderedH)} at (${tx}, ${ty})`);
@@ -1755,15 +1715,19 @@ export async function handleTool(
 
       const slidesService = ctx.google.slides({ version: 'v1', auth: ctx.authClient });
 
-      // First get the current element to read its existing transform and size
-      const pres = await slidesService.presentations.get({ presentationId: a.presentationId });
-      let currentTransform: any = null;
-      let currentSize: any = null;
+      // Field-masked fetch: we only need each element's objectId/transform/size.
+      const pres = await slidesService.presentations.get({
+        presentationId: a.presentationId,
+        fields: 'slides(pageElements(objectId,transform,size))',
+      });
+
+      let currentTransform: slides_v1.Schema$AffineTransform | null = null;
+      let currentSize: slides_v1.Schema$Size | null = null;
       for (const slide of pres.data.slides || []) {
         for (const el of slide.pageElements || []) {
           if (el.objectId === a.objectId) {
-            currentTransform = el.transform;
-            currentSize = el.size;
+            currentTransform = el.transform || null;
+            currentSize = el.size || null;
             break;
           }
         }
@@ -1774,37 +1738,31 @@ export async function handleTool(
         return errorResponse(`Element ${a.objectId} not found in presentation`);
       }
 
-      // Compute new scale factors if width/height provided
-      const origWidth = (currentSize?.width?.magnitude || 3000000);
-      const origHeight = (currentSize?.height?.magnitude || 3000000);
+      const origWidth = currentSize?.width?.magnitude || 3000000;
+      const origHeight = currentSize?.height?.magnitude || 3000000;
       const curScaleX = currentTransform.scaleX || 1;
       const curScaleY = currentTransform.scaleY || 1;
 
-      let newScaleX = curScaleX;
-      let newScaleY = curScaleY;
-      if (a.width !== undefined) {
-        newScaleX = a.width / origWidth;
-      }
-      if (a.height !== undefined) {
-        newScaleY = a.height / origHeight;
-      }
-
+      const newScaleX = a.width !== undefined ? a.width / origWidth : curScaleX;
+      const newScaleY = a.height !== undefined ? a.height / origHeight : curScaleY;
       const newX = a.x ?? (currentTransform.translateX || 0);
       const newY = a.y ?? (currentTransform.translateY || 0);
 
-      const requests: any[] = [{
+      const newTransform: slides_v1.Schema$AffineTransform = {
+        scaleX: newScaleX,
+        scaleY: newScaleY,
+        translateX: newX,
+        translateY: newY,
+        shearX: currentTransform.shearX || 0,
+        shearY: currentTransform.shearY || 0,
+        unit: 'EMU',
+      };
+
+      const requests: slides_v1.Schema$Request[] = [{
         updatePageElementTransform: {
           objectId: a.objectId,
           applyMode: 'ABSOLUTE',
-          transform: {
-            scaleX: newScaleX,
-            scaleY: newScaleY,
-            translateX: newX,
-            translateY: newY,
-            shearX: currentTransform.shearX || 0,
-            shearY: currentTransform.shearY || 0,
-            unit: 'EMU',
-          },
+          transform: newTransform,
         },
       }];
 
@@ -1813,8 +1771,10 @@ export async function handleTool(
         requestBody: { requests },
       });
 
+      const didResize = a.width !== undefined || a.height !== undefined;
+      const action = didResize ? 'Moved/resized' : 'Moved';
       return {
-        content: [{ type: 'text', text: `Moved element ${a.objectId} to (${newX}, ${newY})` }],
+        content: [{ type: 'text', text: `${action} element ${a.objectId} to (${newX}, ${newY})` }],
         isError: false,
       };
     }
@@ -1849,8 +1809,28 @@ export async function handleTool(
       const validation = InsertSlidesLocalImageSchema.safeParse(args);
       if (!validation.success) return errorResponse(validation.error.errors[0].message);
       const a = validation.data;
-      const imageUrl = await uploadImageToDriveForSlides(ctx, a.localImagePath, a.makePublic);
-      return insertImageIntoSlide(ctx, a.presentationId, a.pageObjectId, imageUrl, a.x, a.y, a.width, a.height);
+
+      // Upload briefly as public so the Slides API can fetch the bytes.
+      const { fileId, webContentLink } = await uploadImageToDrive(ctx, a.localImagePath, {
+        makePublic: true,
+      });
+      try {
+        const result = await insertImageIntoSlide(
+          ctx, a.presentationId, a.pageObjectId, webContentLink,
+          a.x, a.y, a.width, a.height,
+        );
+        // Slides stores its own copy once createImage returns, so the intermediary
+        // Drive file is no longer referenced. Delete it (which also removes the
+        // public permission we just granted).
+        await deleteDriveFile(ctx, fileId).catch((err) =>
+          ctx.log(`insertSlidesLocalImage: failed to delete intermediary Drive file ${fileId}`, err),
+        );
+        return result;
+      } catch (err) {
+        // On embed failure, still try to clean up the uploaded file.
+        await deleteDriveFile(ctx, fileId).catch(() => {});
+        throw err;
+      }
     }
 
     default:

--- a/src/utils/driveImageUpload.ts
+++ b/src/utils/driveImageUpload.ts
@@ -1,0 +1,74 @@
+import { existsSync, createReadStream } from 'fs';
+import { basename, extname } from 'path';
+import type { ToolContext } from '../types.js';
+
+const MIME_BY_EXT: { [ext: string]: string } = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.bmp': 'image/bmp',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+};
+
+export interface UploadedImage {
+  fileId: string;
+  webContentLink: string;
+}
+
+export async function uploadImageToDrive(
+  ctx: ToolContext,
+  localFilePath: string,
+  options: { parentFolderId?: string; makePublic?: boolean } = {},
+): Promise<UploadedImage> {
+  const { parentFolderId, makePublic = false } = options;
+
+  if (!existsSync(localFilePath)) {
+    throw new Error(`Image file not found: ${localFilePath}`);
+  }
+
+  const fileName = basename(localFilePath);
+  const ext = extname(localFilePath).toLowerCase();
+  const mimeType = MIME_BY_EXT[ext] || 'application/octet-stream';
+
+  const requestBody: { name: string; mimeType: string; parents?: string[] } = {
+    name: fileName,
+    mimeType,
+  };
+  if (parentFolderId) requestBody.parents = [parentFolderId];
+
+  const drive = ctx.getDrive();
+
+  const uploadResponse = await drive.files.create({
+    requestBody,
+    media: { mimeType, body: createReadStream(localFilePath) },
+    fields: 'id,webViewLink,webContentLink',
+    supportsAllDrives: true,
+  });
+
+  const fileId = uploadResponse.data.id;
+  if (!fileId) throw new Error('Failed to upload image to Drive - no file ID returned');
+
+  if (makePublic) {
+    await drive.permissions.create({
+      fileId,
+      requestBody: { role: 'reader', type: 'anyone' },
+    });
+  }
+
+  const fileInfo = await drive.files.get({
+    fileId,
+    fields: 'webContentLink',
+    supportsAllDrives: true,
+  });
+
+  const webContentLink = fileInfo.data.webContentLink;
+  if (!webContentLink) throw new Error('Failed to get web content link for uploaded image');
+
+  return { fileId, webContentLink };
+}
+
+export async function deleteDriveFile(ctx: ToolContext, fileId: string): Promise<void> {
+  await ctx.getDrive().files.delete({ fileId, supportsAllDrives: true });
+}

--- a/test/schema/tool-registry.test.ts
+++ b/test/schema/tool-registry.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
 import { setupTestServer, type TestContext } from '../helpers/setup-server.js';
 
-const EXPECTED_TOOL_COUNT = 99;
+const EXPECTED_TOOL_COUNT = 104;
 
 const EXPECTED_TOOLS = [
   'search', 'createTextFile', 'updateTextFile', 'createFolder', 'listFolder', 'listSharedDrives',
@@ -21,6 +21,7 @@ const EXPECTED_TOOLS = [
   'styleGoogleSlidesShape', 'setGoogleSlidesBackground',
   'createGoogleSlidesTextBox', 'createGoogleSlidesShape',
   'getGoogleSlidesSpeakerNotes', 'updateGoogleSlidesSpeakerNotes', 'deleteGoogleSlide', 'duplicateSlide', 'reorderSlides', 'replaceAllTextInSlides', 'exportSlideThumbnail',
+  'insertSlidesImageFromUrl', 'insertSlidesLocalImage', 'moveSlideElement', 'deleteSlideElement', 'getSlideElementInfo',
   'createShortcut',
   'lockFile', 'unlockFile',
   'uploadFile', 'downloadFile', 'listPermissions', 'addPermission', 'updatePermission', 'removePermission', 'shareFile', 'getRevisions', 'restoreRevision', 'authGetStatus', 'authListScopes', 'authTestFileAccess',


### PR DESCRIPTION
## Summary

Adds 5 new Google Slides tools for programmatic slide layout:

**Image insertion:**
- `insertSlidesImageFromUrl` — insert an image from a public URL into a slide
- `insertSlidesLocalImage` — upload a local image to Drive and insert into a slide

**Element management:**
- `moveSlideElement` — reposition and/or resize any page element (images, text boxes, shapes) using transform updates with scale-based resizing
- `deleteSlideElement` — remove elements from slides
- `getSlideElementInfo` — diagnostic tool that returns actual rendered bounds (intrinsic size × scale + translate) for all elements on a slide, with off-page detection

These tools enable full programmatic control over slide layout — useful for building presentations with precise figure placement while preserving aspect ratios.

## Test plan
- [x] TypeScript typecheck passes
- [x] Bundle builds successfully
- [x] Tested against live Google Slides API: insert, move, resize, delete, and inspect operations verified on a real presentation
- [x] Off-page detection correctly flags elements extending past slide boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)