### PR TITLE
chore: release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.0.2...v2.1.0) (2026-04-14)
+
+### Features
+
+- **slides:** add `insertSlidesImageFromUrl` and `insertSlidesLocalImage` tools ([8d7ae13](https://github.com/piotr-agier/google-drive-mcp/commit/8d7ae13))
+- **slides:** add element management tools — move, delete, and inspect slide elements ([cb108df](https://github.com/piotr-agier/google-drive-mcp/commit/cb108df))
+
 ## [2.0.2](https://github.com/piotr-agier/google-drive-mcp/compare/v2.0.1...v2.0.2) (2026-04-04)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "2.0.2",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary

- Bump version to 2.1.0
- **feat(slides):** add `insertSlidesImageFromUrl` and `insertSlidesLocalImage` tools
- **feat(slides):** add element management tools — move, delete, and inspect slide elements

## Test plan

- [ ] Verify CI passes
- [ ] Publish to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)