### PR TITLE
feat: configurable OAuth auth server port via GOOGLE_DRIVE_MCP_AUTH_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1322,6 +1322,7 @@ npm run typecheck # Type checking without compilation
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
 | `GOOGLE_DRIVE_MCP_TOKEN_PATH` | Override token storage location | `~/.config/google-drive-mcp/tokens.json` | `/custom/path/tokens.json` |
+| `GOOGLE_DRIVE_MCP_AUTH_PORT` | Starting port for OAuth callback server (uses 5 consecutive ports) | `3000` | `3100` |
 | `DEBUG` | Enable debug logging | (disabled) | `google-drive-mcp:*` |
 
 **External Authentication** (alternative to local OAuth flow):

--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ Notes:
   `drive`, `drive.file`, `drive.readonly`, `documents`, `spreadsheets`, `presentations`, `calendar`, `calendar.events`.
 - Changing scopes usually requires re-authentication.
 
+### Auth Server Port Configuration
+
+During OAuth authentication, a local HTTP server is started to receive the callback. By default it tries ports 3000–3004. If those conflict with other services (e.g., a dev server), you can change the starting port:
+
+```bash
+export GOOGLE_DRIVE_MCP_AUTH_PORT=3100
+```
+
+The server will try 5 consecutive ports starting from the configured value (e.g., 3100–3104).
+
 ### Token Storage
 
 Authentication tokens are stored securely following the XDG Base Directory specification:
@@ -1104,7 +1114,7 @@ OAuth credentials not found. Please provide credentials using one of these metho
 #### "Authentication failed" or Browser doesn't open
 **Possible causes:**
 1. **Wrong credential type**: Must be "Desktop app", not "Web application"
-2. **Port blocked**: Ports 3000-3004 must be available
+2. **Port blocked**: Ports 3000-3004 must be available (or custom range if `GOOGLE_DRIVE_MCP_AUTH_PORT` is set)
 3. **Test user not added**: Add your email in OAuth consent screen
 
 **Solution:**
@@ -1112,8 +1122,11 @@ OAuth credentials not found. Please provide credentials using one of these metho
 # Check if ports are in use
 lsof -i :3000-3004
 
-# Kill processes if needed
+# Option 1: Kill processes if needed
 kill -9 <PID>
+
+# Option 2: Use a different port range
+export GOOGLE_DRIVE_MCP_AUTH_PORT=3100
 
 # Re-run authentication
 npx @piotr-agier/google-drive-mcp auth

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -14,7 +14,7 @@ export class AuthServer {
   private app: express.Express;
   private server: http.Server | null = null;
   private tokenManager: TokenManager;
-  private portRange: { start: number; end: number };
+  public readonly portRange: { start: number; end: number };
   public authCompletedSuccessfully = false; // Flag for standalone script
 
   constructor(oauth2Client: OAuth2Client) {

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -21,7 +21,13 @@ export class AuthServer {
     this.baseOAuth2Client = oauth2Client;
     this.tokenManager = new TokenManager(oauth2Client);
     this.app = express();
-    const portStart = parseInt(process.env.GOOGLE_DRIVE_MCP_AUTH_PORT || '3000', 10);
+    const raw = process.env.GOOGLE_DRIVE_MCP_AUTH_PORT;
+    const portStart = raw ? Number(raw) : 3000;
+    if (!Number.isInteger(portStart) || portStart < 1 || portStart > 65531) {
+      throw new Error(
+        `Invalid GOOGLE_DRIVE_MCP_AUTH_PORT: "${raw}". Must be an integer between 1 and 65531.`
+      );
+    }
     this.portRange = { start: portStart, end: portStart + 4 };
     this.setupRoutes();
   }

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -21,7 +21,8 @@ export class AuthServer {
     this.baseOAuth2Client = oauth2Client;
     this.tokenManager = new TokenManager(oauth2Client);
     this.app = express();
-    this.portRange = { start: 3000, end: 3004 };
+    const portStart = parseInt(process.env.GOOGLE_DRIVE_MCP_AUTH_PORT || '3000', 10);
+    this.portRange = { start: portStart, end: portStart + 4 };
     this.setupRoutes();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,6 +392,7 @@ Examples:
 Environment Variables:
   GOOGLE_DRIVE_OAUTH_CREDENTIALS        Path to OAuth credentials file
   GOOGLE_DRIVE_MCP_TOKEN_PATH           Path to store authentication tokens
+  GOOGLE_DRIVE_MCP_AUTH_PORT            Starting port for OAuth callback server (default: 3000, uses 5 consecutive ports)
 
   Transport Configuration:
   MCP_TRANSPORT                         Transport mode: stdio or http (default: stdio)
@@ -420,8 +421,9 @@ async function runAuthServer(): Promise<void> {
     const success = await authServerInstance.start(true);
 
     if (!success && !authServerInstance.authCompletedSuccessfully) {
+      const { start, end } = authServerInstance.portRange;
       console.error(
-        "Authentication failed. Could not start server or validate existing tokens. Check port availability (3000-3004) and try again."
+        `Authentication failed. Could not start server or validate existing tokens. Check port availability (${start}-${end}) and try again.`
       );
       process.exit(1);
     } else if (authServerInstance.authCompletedSuccessfully) {


### PR DESCRIPTION
## Summary

- Adds `GOOGLE_DRIVE_MCP_AUTH_PORT` environment variable to configure the starting port for the OAuth callback server
- Default behavior unchanged (ports 3000–3004)
- When set, the server tries 5 consecutive ports starting from the configured value (e.g., `GOOGLE_DRIVE_MCP_AUTH_PORT=3100` → tries 3100–3104)

## Motivation

Port 3000 is commonly used by dev servers (React, Next.js, Rails, etc.), causing frequent conflicts when authenticating. This is a one-line change to the `AuthServer` constructor that reads from an env var with a fallback to the existing default.

## Changes

- `src/auth/server.ts`: Read `GOOGLE_DRIVE_MCP_AUTH_PORT` env var in constructor
- `README.md`: Document the new env var in configuration and troubleshooting sections

## Usage

```bash
export GOOGLE_DRIVE_MCP_AUTH_PORT=3100
npx @piotr-agier/google-drive-mcp auth
```