### PR TITLE
feat: add emailMessage support to addPermission and shareFile

### DIFF
--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -423,7 +423,7 @@ export const toolDefinitions: ToolDefinition[] = [
         role: { type: "string", enum: ["owner", "organizer", "fileOrganizer", "writer", "commenter", "reader"], description: "Permission role" },
         type: { type: "string", enum: ["user", "group", "domain", "anyone"], description: "Principal type" },
         sendNotificationEmail: { type: "boolean", description: "Send notification email" },
-        emailMessage: { type: "string", description: "Custom message to include in the notification email" }
+        emailMessage: { type: "string", description: "Custom message to include in the notification email. Ignored unless sendNotificationEmail is true." }
       },
       required: ["fileId", "emailAddress"]
     }
@@ -464,7 +464,7 @@ export const toolDefinitions: ToolDefinition[] = [
         emailAddress: { type: "string", description: "User email" },
         role: { type: "string", enum: ["writer", "commenter", "reader"], description: "Access role" },
         sendNotificationEmail: { type: "boolean", description: "Send notification email" },
-        emailMessage: { type: "string", description: "Custom message to include in the notification email" }
+        emailMessage: { type: "string", description: "Custom message to include in the notification email. Ignored unless sendNotificationEmail is true." }
       },
       required: ["fileId", "emailAddress"]
     }

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -135,6 +135,7 @@ const AddPermissionSchema = z.object({
   role: z.enum(["owner", "organizer", "fileOrganizer", "writer", "commenter", "reader"]).default("reader"),
   type: z.enum(["user", "group", "domain", "anyone"]).default("user"),
   sendNotificationEmail: z.boolean().optional().default(false),
+  emailMessage: z.string().optional(),
 });
 
 const UpdatePermissionSchema = z.object({
@@ -158,6 +159,7 @@ const ShareFileSchema = z.object({
   emailAddress: z.string().email("Valid email is required"),
   role: z.enum(["writer", "commenter", "reader"]).default("reader"),
   sendNotificationEmail: z.boolean().optional().default(true),
+  emailMessage: z.string().optional(),
 });
 
 const ConvertPdfToGoogleDocSchema = z.object({
@@ -420,7 +422,8 @@ export const toolDefinitions: ToolDefinition[] = [
         emailAddress: { type: "string", description: "Target user/group email" },
         role: { type: "string", enum: ["owner", "organizer", "fileOrganizer", "writer", "commenter", "reader"], description: "Permission role" },
         type: { type: "string", enum: ["user", "group", "domain", "anyone"], description: "Principal type" },
-        sendNotificationEmail: { type: "boolean", description: "Send notification email" }
+        sendNotificationEmail: { type: "boolean", description: "Send notification email" },
+        emailMessage: { type: "string", description: "Custom message to include in the notification email" }
       },
       required: ["fileId", "emailAddress"]
     }
@@ -460,7 +463,8 @@ export const toolDefinitions: ToolDefinition[] = [
         fileId: { type: "string", description: "Google Drive file ID" },
         emailAddress: { type: "string", description: "User email" },
         role: { type: "string", enum: ["writer", "commenter", "reader"], description: "Access role" },
-        sendNotificationEmail: { type: "boolean", description: "Send notification email" }
+        sendNotificationEmail: { type: "boolean", description: "Send notification email" },
+        emailMessage: { type: "string", description: "Custom message to include in the notification email" }
       },
       required: ["fileId", "emailAddress"]
     }
@@ -1314,6 +1318,7 @@ export async function handleTool(
           emailAddress: data.emailAddress,
         },
         sendNotificationEmail: data.sendNotificationEmail,
+        ...(data.emailMessage && { emailMessage: data.emailMessage }),
         fields: 'id,type,role,emailAddress',
         supportsAllDrives: true,
       });
@@ -1417,6 +1422,7 @@ export async function handleTool(
           emailAddress: data.emailAddress,
         },
         sendNotificationEmail: data.sendNotificationEmail,
+        ...(data.emailMessage && { emailMessage: data.emailMessage }),
         fields: 'id,type,role,emailAddress',
         supportsAllDrives: true,
       });

--- a/test/integration/drive.test.ts
+++ b/test/integration/drive.test.ts
@@ -410,6 +410,41 @@ describe('Drive tools', () => {
       assert.equal(res.isError, false);
       assert.ok(res.content[0].text.includes('No changes needed'));
     });
+
+    it('addPermission forwards emailMessage to permissions.create', async () => {
+      ctx.mocks.drive.service.permissions.list._resetImpl();
+      const res = await callTool(ctx.client, 'addPermission', {
+        fileId: 'file-1', emailAddress: 'user@example.com', role: 'reader', type: 'user',
+        sendNotificationEmail: true, emailMessage: 'Welcome!',
+      });
+      assert.equal(res.isError, false);
+      const createCalls = ctx.mocks.drive.tracker.getCalls('permissions.create');
+      assert.ok(createCalls.length >= 1);
+      assert.equal(createCalls[0].args[0].emailMessage, 'Welcome!');
+    });
+
+    it('shareFile forwards emailMessage to permissions.create', async () => {
+      ctx.mocks.drive.service.permissions.list._setImpl(async () => ({ data: { permissions: [] } }));
+      const res = await callTool(ctx.client, 'shareFile', {
+        fileId: 'file-1', emailAddress: 'user@example.com', role: 'writer',
+        emailMessage: 'Sharing this with you',
+      });
+      assert.equal(res.isError, false);
+      const createCalls = ctx.mocks.drive.tracker.getCalls('permissions.create');
+      assert.ok(createCalls.length >= 1);
+      assert.equal(createCalls[0].args[0].emailMessage, 'Sharing this with you');
+    });
+
+    it('shareFile omits emailMessage when not provided', async () => {
+      ctx.mocks.drive.service.permissions.list._setImpl(async () => ({ data: { permissions: [] } }));
+      const res = await callTool(ctx.client, 'shareFile', {
+        fileId: 'file-1', emailAddress: 'user@example.com', role: 'writer',
+      });
+      assert.equal(res.isError, false);
+      const createCalls = ctx.mocks.drive.tracker.getCalls('permissions.create');
+      assert.ok(createCalls.length >= 1);
+      assert.equal('emailMessage' in createCalls[0].args[0], false);
+    });
   });
 
   // --- auth diagnostics ---


### PR DESCRIPTION
## Summary

- Adds `emailMessage` optional parameter to `addPermission` and `shareFile` tools
- Wires it through at all three layers: Zod validation schema, MCP tool input schema, and the `permissions.create` API call
- Mirrors the "Add a message" field in the Google Drive sharing UI

The Google Drive API has always supported [`emailMessage` on `permissions.create`](https://developers.google.com/drive/api/reference/rest/v3/permissions/create) — this just surfaces it through the MCP server.

## Changes

One file, 8 insertions, 2 deletions in `src/tools/drive.ts`:

1. `AddPermissionSchema` — added `emailMessage: z.string().optional()`
2. `ShareFileSchema` — added `emailMessage: z.string().optional()`
3. `addPermission` tool input schema — added `emailMessage` property
4. `shareFile` tool input schema — added `emailMessage` property
5. `addPermission` handler — passes `emailMessage` to `permissions.create`
6. `shareFile` handler — passes `emailMessage` to `permissions.create`

## Test

- TypeScript compiles clean (`npm run typecheck`)
- Build passes (`npm run build`)
- Tested locally: sharing a file with `emailMessage` sends the custom message in the notification email

Closes #99