### PR TITLE
Add tabId support to insertText/deleteRange + fix renameDocumentTab

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -722,13 +722,15 @@ const GetGoogleDocContentSchema = z.object({
 const InsertTextSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
   text: z.string().min(1, "Text to insert is required"),
-  index: z.number().int().min(1, "Index must be at least 1 (1-based)")
+  index: z.number().int().min(1, "Index must be at least 1 (1-based)"),
+  tabId: z.string().optional()
 });
 
 const DeleteRangeSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
   startIndex: z.number().int().min(1, "Start index must be at least 1"),
-  endIndex: z.number().int().min(1, "End index must be at least 1")
+  endIndex: z.number().int().min(1, "End index must be at least 1"),
+  tabId: z.string().optional()
 }).refine(data => data.endIndex > data.startIndex, {
   message: "End index must be greater than start index",
   path: ["endIndex"]
@@ -952,26 +954,28 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "insertText",
-    description: "Insert text at a specific index in a Google Doc (surgical edit, doesn't replace entire doc)",
+    description: "Insert text at a specific index in a Google Doc (surgical edit, doesn't replace entire doc). For multi-tab docs, specify tabId to target a specific tab.",
     inputSchema: {
       type: "object",
       properties: {
         documentId: { type: "string", description: "The document ID" },
         text: { type: "string", description: "Text to insert" },
-        index: { type: "number", description: "Position to insert at (1-based)" }
+        index: { type: "number", description: "Position to insert at (1-based)" },
+        tabId: { type: "string", description: "Optional. Tab ID to insert into (from listDocumentTabs). If omitted, inserts into the first/default tab." }
       },
       required: ["documentId", "text", "index"]
     }
   },
   {
     name: "deleteRange",
-    description: "Delete content between start and end indices in a Google Doc",
+    description: "Delete content between start and end indices in a Google Doc. For multi-tab docs, specify tabId to target a specific tab.",
     inputSchema: {
       type: "object",
       properties: {
         documentId: { type: "string", description: "The document ID" },
         startIndex: { type: "number", description: "Start index (1-based, inclusive)" },
-        endIndex: { type: "number", description: "End index (exclusive)" }
+        endIndex: { type: "number", description: "End index (exclusive)" },
+        tabId: { type: "string", description: "Optional. Tab ID to delete from (from listDocumentTabs). If omitted, deletes from the first/default tab." }
       },
       required: ["documentId", "startIndex", "endIndex"]
     }
@@ -1789,13 +1793,16 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       }
       const a = validation.data;
 
+      const location: { index: number; tabId?: string } = { index: a.index };
+      if (a.tabId) location.tabId = a.tabId;
+
       const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
       await docs.documents.batchUpdate({
         documentId: a.documentId,
         requestBody: {
           requests: [{
             insertText: {
-              location: { index: a.index },
+              location,
               text: a.text
             }
           }]
@@ -1803,7 +1810,7 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       });
 
       return {
-        content: [{ type: "text", text: `Successfully inserted ${a.text.length} characters at index ${a.index}` }],
+        content: [{ type: "text", text: `Successfully inserted ${a.text.length} characters at index ${a.index}${a.tabId ? ` in tab ${a.tabId}` : ''}` }],
         isError: false
       };
     }
@@ -1819,17 +1826,18 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
         return errorResponse("endIndex must be greater than startIndex");
       }
 
+      const range: { startIndex: number; endIndex: number; tabId?: string } = {
+        startIndex: a.startIndex,
+        endIndex: a.endIndex
+      };
+      if (a.tabId) range.tabId = a.tabId;
+
       const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
       await docs.documents.batchUpdate({
         documentId: a.documentId,
         requestBody: {
           requests: [{
-            deleteContentRange: {
-              range: {
-                startIndex: a.startIndex,
-                endIndex: a.endIndex
-              }
-            }
+            deleteContentRange: { range }
           }]
         }
       });
@@ -2954,8 +2962,10 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
       await docs.documents.batchUpdate({
         documentId: a.documentId,
-        // updateDocumentTabProperties is not yet in the googleapis TypeScript types — cast required
-        requestBody: { requests: [{ updateDocumentTabProperties: { tabId: a.tabId, tabProperties: { title: a.title }, fields: 'title' } } as any] }
+        // updateDocumentTabProperties is not yet in the googleapis TypeScript types — cast required.
+        // Per Google Docs API spec: tabId lives INSIDE tabProperties (it's the tab identifier),
+        // and `fields` is a FieldMask for which properties to update (excludes tabId).
+        requestBody: { requests: [{ updateDocumentTabProperties: { tabProperties: { tabId: a.tabId, title: a.title }, fields: 'title' } } as any] }
       });
 
       return { content: [{ type: 'text', text: `Renamed tab ${a.tabId} to "${a.title}".` }], isError: false };


### PR DESCRIPTION
## What this fixes

Three related issues that prevented content-editing tools from working with multi-tab Google Docs:

### 1. `insertText` — add optional `tabId` parameter

Without it, `insertText` always targets the first/default tab. The underlying Google Docs API `Location` object supports `tabId`, but the tool didn't expose it. Adding optional `tabId` to the schema and passing it through via `location.tabId`.

### 2. `deleteRange` — add optional `tabId` parameter

Same reasoning, applied to `Range.tabId`.

### 3. `renameDocumentTab` — fix "Invalid JSON payload" error

Current code sends:
\`\`\`json
{ "updateDocumentTabProperties": { "tabId": "t.xxx", "tabProperties": { "title": "..." }, "fields": "title" } }
\`\`\`

Google rejects this with:
\`\`\`
Invalid JSON payload received. Unknown name "tabId" at 'requests[0].update_document_tab_properties': Cannot find field.
\`\`\`

Per the [Google Docs API spec](https://developers.google.com/workspace/docs/api/reference/rest/v1/documents#TabProperties), `tabId` lives **inside** `tabProperties` (it's the immutable tab identifier). Fixed request body:
\`\`\`json
{ "updateDocumentTabProperties": { "tabProperties": { "tabId": "t.xxx", "title": "..." }, "fields": "title" } }
\`\`\`

## Why this matters

Without these fixes, you can `addDocumentTab` but can't actually write anything to the new tab — defeating the purpose of multi-tab support. I hit this while trying to add a new tab with v2 mailserie-content to an existing doc; `insertText` silently landed in Tab 1 instead, `renameDocumentTab` errored out, and I had to fall back to creating a standalone doc.

## Testing

- Backwards compatible: `tabId` is optional on both `insertText` and `deleteRange`. Existing callers get the same behavior (first tab).
- `renameDocumentTab`: verified the new payload matches the Google Docs API spec for `UpdateDocumentTabPropertiesRequest` (tabProperties wraps tabId, fields mask excludes tabId since it's immutable).
- TypeScript build passes (`npm run build`).

## Out of scope (follow-up ideas)

- `updateGoogleDoc` and `findAndReplaceInDoc` don't yet support scoping to a specific tab either. `replaceAllText` has a `tabsCriteria` field that could be wired up; `updateGoogleDoc` would need a read-tab + delete-range + insert-text sequence. Happy to do these in a follow-up PR if there's interest.