### PR TITLE
test(docs): assert tabId payload shape + deleteRange msg polish

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1843,7 +1843,7 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       });
 
       return {
-        content: [{ type: "text", text: `Successfully deleted content from index ${a.startIndex} to ${a.endIndex}` }],
+        content: [{ type: "text", text: `Successfully deleted content from index ${a.startIndex} to ${a.endIndex}${a.tabId ? ` in tab ${a.tabId}` : ''}` }],
         isError: false
       };
     }

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -167,6 +167,20 @@ describe('Docs tools', () => {
       assert.ok(res.content[0].text.includes('inserted'));
     });
 
+    it('with tabId forwards tabId to Location', async () => {
+      const res = await callTool(ctx.client, 'insertText', { documentId: 'doc-1', text: 'hello', index: 1, tabId: 'tab-7' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('tab-7'));
+
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      const lastCall = calls[calls.length - 1];
+      const requests = lastCall?.args?.[0]?.requestBody?.requests;
+      assert.equal(requests?.length, 1);
+      assert.equal(requests[0].insertText.location.tabId, 'tab-7');
+      assert.equal(requests[0].insertText.location.index, 1);
+      assert.equal(requests[0].insertText.text, 'hello');
+    });
+
     it('validation error', async () => {
       const res = await callTool(ctx.client, 'insertText', {});
       assert.equal(res.isError, true);
@@ -179,6 +193,20 @@ describe('Docs tools', () => {
       const res = await callTool(ctx.client, 'deleteRange', { documentId: 'doc-1', startIndex: 1, endIndex: 5 });
       assert.equal(res.isError, false);
       assert.ok(res.content[0].text.includes('deleted'));
+    });
+
+    it('with tabId forwards tabId to Range', async () => {
+      const res = await callTool(ctx.client, 'deleteRange', { documentId: 'doc-1', startIndex: 1, endIndex: 5, tabId: 'tab-7' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('tab-7'));
+
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      const lastCall = calls[calls.length - 1];
+      const requests = lastCall?.args?.[0]?.requestBody?.requests;
+      assert.equal(requests?.length, 1);
+      assert.equal(requests[0].deleteContentRange.range.tabId, 'tab-7');
+      assert.equal(requests[0].deleteContentRange.range.startIndex, 1);
+      assert.equal(requests[0].deleteContentRange.range.endIndex, 5);
     });
 
     it('validation: endIndex must be > startIndex', async () => {
@@ -1193,6 +1221,17 @@ describe('Docs tools', () => {
     it('renameDocumentTab happy path', async () => {
       const res = await callTool(ctx.client, 'renameDocumentTab', { documentId: 'doc-1', tabId: 'tab-1', title: 'Renamed' });
       assert.equal(res.isError, false);
+
+      // tabId must live INSIDE tabProperties — Google rejects the payload if it's at the request root.
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      const lastCall = calls[calls.length - 1];
+      const requests = lastCall?.args?.[0]?.requestBody?.requests;
+      assert.equal(requests?.length, 1);
+      const req = requests[0].updateDocumentTabProperties;
+      assert.equal(req.tabProperties.tabId, 'tab-1');
+      assert.equal(req.tabProperties.title, 'Renamed');
+      assert.equal(req.fields, 'title');
+      assert.equal(req.tabId, undefined, 'tabId must not be at the request root');
     });
 
     it('insertSmartChip happy path', async () => {


### PR DESCRIPTION
## Summary

- **Tighter regression tests** on the three tools whose payload shape PR #101 touched. The existing happy-path tests only asserted `isError === false`, which would have passed the very bug PR #101 fixed (misplaced `tabId` in `renameDocumentTab`). Now they inspect the mocked `documents.batchUpdate` request body:
  - `renameDocumentTab`: asserts `requests[0].updateDocumentTabProperties.tabProperties.tabId === 'tab-1'` and explicitly that `tabId` is **not** at the request root.
  - `insertText` (new `with tabId` case): asserts `requests[0].insertText.location.tabId === 'tab-7'`.
  - `deleteRange` (new `with tabId` case): asserts `requests[0].deleteContentRange.range.tabId === 'tab-7'`.
  Pattern matches `insertSmartChip` test at `test/integration/docs.test.ts:1204-1209`.
- **`deleteRange` success message** now appends ` in tab ${tabId}` when set, matching `insertText`'s format from PR #101.

## Test plan

- [x] `npm run build` (typecheck clean)
- [x] `npm test` — 273/273 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)