### PR TITLE
feat(docs): add optional tabId to findAndReplaceInDoc

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -889,6 +889,7 @@ const FindAndReplaceInDocSchema = z.object({
   replaceText: z.string(),
   matchCase: z.boolean().optional().default(false),
   dryRun: z.boolean().optional().default(false),
+  tabId: z.string().optional(),
 });
 
 const AddDocumentTabSchema = z.object({
@@ -1118,7 +1119,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "findAndReplaceInDoc",
-    description: "Find and replace text across a Google Document. Dry-run mode counts matches from paragraph text only (may differ from actual replacements which cover tables, headers, footers, etc.)",
+    description: "Find and replace text across a Google Document. Dry-run mode counts matches from paragraph text only (may differ from actual replacements which cover tables, headers, footers, etc.). For multi-tab docs, specify tabId to scope replacements to a single tab.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1126,7 +1127,8 @@ export const toolDefinitions: ToolDefinition[] = [
         findText: { type: "string", description: "Text to find" },
         replaceText: { type: "string", description: "Replacement text" },
         matchCase: { type: "boolean", description: "Case-sensitive match (default: false)" },
-        dryRun: { type: "boolean", description: "Only count approximate matches from paragraph text, do not modify document (default: false)" }
+        dryRun: { type: "boolean", description: "Only count approximate matches from paragraph text, do not modify document (default: false). Ignores tabId — always scans the full document body." },
+        tabId: { type: "string", description: "Optional. Tab ID to scope replacements to (from listDocumentTabs). If omitted, replaces across all tabs." }
       },
       required: ["documentId", "findText", "replaceText"]
     }
@@ -2283,26 +2285,26 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
         };
       }
 
+      const replaceAllText: {
+        containsText: { text: string; matchCase: boolean };
+        replaceText: string;
+        tabsCriteria?: { tabIds: string[] };
+      } = {
+        containsText: { text: a.findText, matchCase: a.matchCase },
+        replaceText: a.replaceText,
+      };
+      if (a.tabId) replaceAllText.tabsCriteria = { tabIds: [a.tabId] };
+
       const response = await docs.documents.batchUpdate({
         documentId: a.documentId,
         requestBody: {
-          requests: [
-            {
-              replaceAllText: {
-                containsText: {
-                  text: a.findText,
-                  matchCase: a.matchCase,
-                },
-                replaceText: a.replaceText,
-              },
-            },
-          ],
+          requests: [{ replaceAllText }],
         },
       });
 
       const occurrences = response.data.replies?.[0]?.replaceAllText?.occurrencesChanged ?? 0;
       return {
-        content: [{ type: 'text', text: `Replaced ${occurrences} occurrence(s) of "${a.findText}".` }],
+        content: [{ type: 'text', text: `Replaced ${occurrences} occurrence(s) of "${a.findText}"${a.tabId ? ` in tab ${a.tabId}` : ''}.` }],
         isError: false,
       };
     }

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -447,6 +447,33 @@ describe('Docs tools', () => {
       assert.ok(res.content[0].text.includes('found 2 occurrence'));
     });
 
+    it('with tabId scopes replacement via tabsCriteria', async () => {
+      const res = await callTool(ctx.client, 'findAndReplaceInDoc', {
+        documentId: 'doc-1', findText: 'Hello', replaceText: 'Hi', tabId: 'tab-2',
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('tab-2'));
+
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      const lastCall = calls[calls.length - 1];
+      const requests = lastCall?.args?.[0]?.requestBody?.requests;
+      assert.equal(requests?.length, 1);
+      assert.deepEqual(requests[0].replaceAllText.tabsCriteria, { tabIds: ['tab-2'] });
+      assert.equal(requests[0].replaceAllText.containsText.text, 'Hello');
+    });
+
+    it('without tabId omits tabsCriteria', async () => {
+      const res = await callTool(ctx.client, 'findAndReplaceInDoc', {
+        documentId: 'doc-1', findText: 'Hello', replaceText: 'Hi',
+      });
+      assert.equal(res.isError, false);
+
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      const lastCall = calls[calls.length - 1];
+      const requests = lastCall?.args?.[0]?.requestBody?.requests;
+      assert.equal(requests[0].replaceAllText.tabsCriteria, undefined);
+    });
+
     it('validation error', async () => {
       const res = await callTool(ctx.client, 'findAndReplaceInDoc', {});
       assert.equal(res.isError, true);


### PR DESCRIPTION
## Summary

Follow-up to PR #101, which added `tabId` to `insertText` / `deleteRange` but left `findAndReplaceInDoc` tab-unaware. Without it, replacements in a multi-tab doc hit every tab even when the caller only wanted one scoped.

- Optional `tabId` on the tool schema.
- Handler forwards it as `replaceAllText.tabsCriteria.tabIds = [tabId]` per the Docs API.
- Success message appends \`in tab \${tabId}\` when set.
- Behavior unchanged when `tabId` is omitted.
- `dryRun` paragraph-text scan is still full-document; noted in the tabId field description as a deliberate limitation to keep the dry-run simple.

## Test plan

- [x] `npm run build` (typecheck clean)
- [x] `npm test` — 273/273 pass
- [x] New test asserts `requests[0].replaceAllText.tabsCriteria` is `{ tabIds: ['tab-2'] }` when `tabId` is provided.
- [x] New test asserts `tabsCriteria` is `undefined` when `tabId` is omitted (regression guard on the default path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)