### PR TITLE
feat(docs): add optional tabId to updateGoogleDoc (atomic rewrite)

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -711,7 +711,8 @@ const CreateGoogleDocSchema = z.object({
 
 const UpdateGoogleDocSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
-  content: z.string()
+  content: z.string(),
+  tabId: z.string().optional()
 });
 
 const GetGoogleDocContentSchema = z.object({
@@ -942,12 +943,13 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "updateGoogleDoc",
-    description: "Update an existing Google Doc",
+    description: "Update an existing Google Doc (replaces all content). For multi-tab docs, specify tabId to replace a single tab's content atomically; leaves other tabs untouched.",
     inputSchema: {
       type: "object",
       properties: {
         documentId: { type: "string", description: "Doc ID" },
-        content: { type: "string", description: "New content" }
+        content: { type: "string", description: "New content" },
+        tabId: { type: "string", description: "Optional. Tab ID to replace (from listDocumentTabs). If set, delete+insert run in a single atomic batchUpdate scoped to that tab." }
       },
       required: ["documentId", "content"]
     }
@@ -1455,6 +1457,50 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       const a = validation.data;
 
       const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
+
+      if (a.tabId) {
+        // Tab-scoped path: single atomic batchUpdate so a failed insert can't leave the tab wiped.
+        const document = await docs.documents.get({ documentId: a.documentId, includeTabsContent: true });
+        const tabs = (document.data as any).tabs as any[] | undefined;
+        const tab = tabs ? findTabById(tabs, a.tabId) : null;
+        if (!tab) {
+          return errorResponse(`Tab with ID "${a.tabId}" not found. Use listDocumentTabs to see available tabs.`);
+        }
+
+        const bodyContent = tab.documentTab?.body?.content;
+        const lastEndIndex = bodyContent?.[bodyContent.length - 1]?.endIndex ?? 1;
+        const deleteEndIndex = Math.max(1, lastEndIndex - 1);
+
+        const requests: any[] = [];
+        if (deleteEndIndex > 1) {
+          requests.push({
+            deleteContentRange: {
+              range: { startIndex: 1, endIndex: deleteEndIndex, tabId: a.tabId }
+            }
+          });
+        }
+        requests.push({
+          insertText: { location: { index: 1, tabId: a.tabId }, text: a.content }
+        });
+        requests.push({
+          updateParagraphStyle: {
+            range: { startIndex: 1, endIndex: a.content.length + 1, tabId: a.tabId },
+            paragraphStyle: { namedStyleType: 'NORMAL_TEXT' },
+            fields: 'namedStyleType'
+          }
+        });
+
+        await docs.documents.batchUpdate({
+          documentId: a.documentId,
+          requestBody: { requests }
+        });
+
+        return {
+          content: [{ type: "text", text: `Updated Google Doc: ${document.data.title} (tab: ${a.tabId})` }],
+          isError: false
+        };
+      }
+
       const document = await docs.documents.get({ documentId: a.documentId });
 
       // Delete all content

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -151,6 +151,106 @@ describe('Docs tools', () => {
       const res = await callTool(ctx.client, 'updateGoogleDoc', { documentId: 'doc-1', content: 'New content' });
       assert.equal(res.isError, false);
       assert.ok(res.content[0].text.includes('Updated Google Doc'));
+
+      // Non-tabId path: still two separate batchUpdate calls (existing behavior).
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      assert.equal(calls.length, 2);
+    });
+
+    it('with tabId issues a single atomic batchUpdate scoped to the tab', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Multi-Tab Doc',
+          tabs: [
+            { tabProperties: { tabId: 'tab-1', title: 'Tab1' }, documentTab: { body: { content: [{ endIndex: 5 }] } } },
+            { tabProperties: { tabId: 'tab-2', title: 'Tab2' }, documentTab: { body: { content: [{ endIndex: 20 }] } } },
+          ],
+        },
+      }));
+      const res = await callTool(ctx.client, 'updateGoogleDoc', { documentId: 'doc-1', content: 'New tab content', tabId: 'tab-2' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('tab: tab-2'));
+
+      // Verify documents.get was called with includeTabsContent.
+      const getCalls = ctx.mocks.docs.tracker.getCalls('documents.get');
+      assert.equal(getCalls[getCalls.length - 1]?.args?.[0]?.includeTabsContent, true);
+
+      // Exactly one batchUpdate — atomic.
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      assert.equal(calls.length, 1);
+
+      const requests = calls[0]?.args?.[0]?.requestBody?.requests;
+      assert.equal(requests?.length, 3);
+      assert.equal(requests[0].deleteContentRange.range.tabId, 'tab-2');
+      assert.equal(requests[0].deleteContentRange.range.startIndex, 1);
+      assert.equal(requests[0].deleteContentRange.range.endIndex, 19);
+      assert.equal(requests[1].insertText.location.tabId, 'tab-2');
+      assert.equal(requests[1].insertText.location.index, 1);
+      assert.equal(requests[1].insertText.text, 'New tab content');
+      assert.equal(requests[2].updateParagraphStyle.range.tabId, 'tab-2');
+    });
+
+    it('with tabId finds nested child tab', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Nested',
+          tabs: [
+            {
+              tabProperties: { tabId: 'tab-1', title: 'Tab1' },
+              documentTab: { body: { content: [{ endIndex: 5 }] } },
+              childTabs: [
+                { tabProperties: { tabId: 'tab-1-1', title: 'Child' }, documentTab: { body: { content: [{ endIndex: 8 }] } } },
+              ],
+            },
+          ],
+        },
+      }));
+      const res = await callTool(ctx.client, 'updateGoogleDoc', { documentId: 'doc-1', content: 'deep', tabId: 'tab-1-1' });
+      assert.equal(res.isError, false);
+
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      assert.equal(calls.length, 1);
+      const requests = calls[0]?.args?.[0]?.requestBody?.requests;
+      assert.equal(requests[0].deleteContentRange.range.tabId, 'tab-1-1');
+      assert.equal(requests[0].deleteContentRange.range.endIndex, 7);
+    });
+
+    it('with tabId on empty tab: skips deleteContentRange', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Multi-Tab Doc',
+          tabs: [
+            { tabProperties: { tabId: 'tab-1', title: 'Empty' }, documentTab: { body: { content: [{ endIndex: 1 }] } } },
+          ],
+        },
+      }));
+      const res = await callTool(ctx.client, 'updateGoogleDoc', { documentId: 'doc-1', content: 'fresh', tabId: 'tab-1' });
+      assert.equal(res.isError, false);
+
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      assert.equal(calls.length, 1);
+      const requests = calls[0]?.args?.[0]?.requestBody?.requests;
+      assert.equal(requests?.length, 2);
+      assert.ok('insertText' in requests[0]);
+      assert.ok('updateParagraphStyle' in requests[1]);
+    });
+
+    it('unknown tabId returns error and issues no batchUpdate', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Multi-Tab Doc',
+          tabs: [
+            { tabProperties: { tabId: 'tab-1', title: 'Tab1' }, documentTab: { body: { content: [{ endIndex: 5 }] } } },
+          ],
+        },
+      }));
+      const res = await callTool(ctx.client, 'updateGoogleDoc', { documentId: 'doc-1', content: 'x', tabId: 'missing' });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text.includes('Tab with ID "missing" not found'));
+      assert.ok(res.content[0].text.includes('listDocumentTabs'));
+
+      const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
+      assert.equal(calls.length, 0);
     });
 
     it('validation error', async () => {


### PR DESCRIPTION
## Summary

Completes the tabId surface started in PR #101: `insertText`, `deleteRange`, and `findAndReplaceInDoc` (PR #103) all support `tabId`; `updateGoogleDoc` now does too.

### Why atomic matters here

The existing non-tabId path issues **two** `batchUpdate` calls (delete, then insert + style). If the insert fails after a successful delete, the doc is left empty — latent data-loss window. The new tab-scoped path fixes that failure mode **for the tab case** by putting `deleteContentRange` + `insertText` + `updateParagraphStyle` in one `batchUpdate` call; `batchUpdate` is atomic server-side, so either all three apply or none do.

The non-tabId path is deliberately untouched — unifying it would change behavior for every existing caller, which belongs in its own PR.

### Mechanics

- `UpdateGoogleDocSchema` gets optional `tabId`.
- Tab-scoped branch: `documents.get({ includeTabsContent: true })` → `findTabById` (helper reused from `readGoogleDoc`, `src/tools/docs.ts:54-65`) → compute the tab's `deleteEndIndex` from `tab.documentTab.body.content[last].endIndex` → build a single `batchUpdate` request list with `tabId` on every `range`/`location`.
- Unknown tabId returns the exact wording from `readGoogleDoc` (`Tab with ID "..." not found. Use listDocumentTabs to see available tabs.`).
- Empty-tab case skips `deleteContentRange` (mirrors the existing `deleteEndIndex > 1` guard in the non-tabId path).
- Success message appends ` (tab: \${tabId})` when set.

## Test plan

- [x] `npm run build` (typecheck clean)
- [x] `npm test` — 275/275 pass (4 new cases)
- [x] Tests asserting:
  - Non-tabId path still issues exactly two batchUpdate calls (regression guard on the untouched path).
  - With tabId: exactly one batchUpdate, three requests, every range/location carries the tabId.
  - Nested child-tab resolution via `findTabById`.
  - Empty tab: no `deleteContentRange`, only insert + style.
  - Unknown tabId: readGoogleDoc-style error, zero batchUpdate calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)