### PR TITLE
chore: prepare release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.2.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.1.0...v2.2.0) (2026-04-20)
+
+### Features
+
+- **docs:** add optional `tabId` to `insertText`, `deleteRange`, `findAndReplaceInDoc`, and `updateGoogleDoc` for targeting specific tabs ([e2b5748](https://github.com/piotr-agier/google-drive-mcp/commit/e2b5748), [3bbf24f](https://github.com/piotr-agier/google-drive-mcp/commit/3bbf24f), [6d29b04](https://github.com/piotr-agier/google-drive-mcp/commit/6d29b04))
+- **auth:** add `GOOGLE_DRIVE_MCP_AUTH_PORT` env var for configurable OAuth callback port ([95615b3](https://github.com/piotr-agier/google-drive-mcp/commit/95615b3), [f16fc3f](https://github.com/piotr-agier/google-drive-mcp/commit/f16fc3f))
+- **drive:** add `emailMessage` support to `addPermission` and `shareFile` ([2fa3f52](https://github.com/piotr-agier/google-drive-mcp/commit/2fa3f52))
+
+### Bug Fixes
+
+- **docs:** fix `renameDocumentTab` ([e2b5748](https://github.com/piotr-agier/google-drive-mcp/commit/e2b5748))
+
 ## [2.1.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.0.2...v2.1.0) (2026-04-14)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
## Summary

Release 2.2.0 — bumps `package.json`/`package-lock.json` and adds CHANGELOG entry.

### Features
- **docs:** optional `tabId` on `insertText`, `deleteRange`, `findAndReplaceInDoc`, `updateGoogleDoc`
- **auth:** `GOOGLE_DRIVE_MCP_AUTH_PORT` env var for configurable OAuth callback port (with validation)
- **drive:** `emailMessage` support on `addPermission` and `shareFile`

### Bug Fixes
- **docs:** fix `renameDocumentTab`

## Test plan
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] Tag `v2.2.0` after merge