### PR TITLE
feat(auth): support domain-wide delegation via GOOGLE_DRIVE_MCP_SUBJECT

### DIFF
--- a/src/auth/externalAuth.ts
+++ b/src/auth/externalAuth.ts
@@ -3,8 +3,8 @@
 // ---------------------------------------------------------------------------
 
 import { OAuth2Client } from 'google-auth-library';
-import { GoogleAuth } from 'google-auth-library';
-import { DEFAULT_SCOPES } from './scopes.js';
+import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
+import { resolveOAuthScopes } from './scopes.js';
 
 // ---------------------------------------------------------------------------
 // Service Account mode
@@ -16,18 +16,48 @@ export function isServiceAccountMode(): boolean {
 }
 
 /**
+ * Build `GoogleAuth` options from the current environment.
+ *
+ * When `GOOGLE_DRIVE_MCP_SUBJECT` is set, the returned options include
+ * `clientOptions.subject`, which instructs `GoogleAuth` to mint a JWT that
+ * impersonates the given user via domain-wide delegation. The Workspace admin
+ * must have authorized the service account's client ID for the requested
+ * scopes under Security → API controls → Manage Domain-wide Delegation.
+ *
+ * Scopes are resolved via {@link resolveOAuthScopes}, so `GOOGLE_DRIVE_MCP_SCOPES`
+ * narrows the SA's authority the same way it does for interactive OAuth.
+ *
+ * Exported so tests can assert the shape without hitting the filesystem.
+ */
+export function buildServiceAccountAuthOptions(): GoogleAuthOptions {
+  const keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS!;
+  const subject = process.env.GOOGLE_DRIVE_MCP_SUBJECT?.trim();
+
+  const options: GoogleAuthOptions = {
+    keyFile,
+    scopes: resolveOAuthScopes(),
+  };
+
+  if (subject) {
+    options.clientOptions = { subject };
+  }
+
+  return options;
+}
+
+/**
  * Create an authorized client from a service account JSON key file.
  * `GoogleAuth` handles JWT signing and token refresh automatically.
  */
 export async function createServiceAccountAuth(): Promise<any> {
-  const keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS!;
-  console.error(`Using service account credentials from ${keyFile}`);
+  const options = buildServiceAccountAuthOptions();
+  const subject = (options.clientOptions as { subject?: string } | undefined)?.subject;
+  console.error(
+    `Using service account credentials from ${options.keyFile}` +
+      (subject ? ` (impersonating ${subject} via domain-wide delegation)` : ''),
+  );
 
-  const auth = new GoogleAuth({
-    keyFile,
-    scopes: [...DEFAULT_SCOPES],
-  });
-
+  const auth = new GoogleAuth(options);
   const client = await auth.getClient();
   console.error('Service account authentication successful');
   return client;

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,6 +401,8 @@ Environment Variables:
 
   Service Account Mode:
   GOOGLE_APPLICATION_CREDENTIALS        Path to service account JSON key file
+  GOOGLE_DRIVE_MCP_SUBJECT              Workspace user to impersonate via domain-wide delegation (optional)
+  GOOGLE_DRIVE_MCP_SCOPES               Comma-separated scopes to request (aliases or full URLs; defaults to all Drive/Docs/Sheets/Slides/Calendar scopes)
 
   External OAuth Token Mode:
   GOOGLE_DRIVE_MCP_ACCESS_TOKEN         Pre-obtained Google OAuth access token

--- a/test/external-auth.test.ts
+++ b/test/external-auth.test.ts
@@ -6,7 +6,9 @@ import {
   isServiceAccountMode,
   validateExternalTokenConfig,
   createExternalOAuth2Client,
+  buildServiceAccountAuthOptions,
 } from '../src/auth/externalAuth.js';
+import { SCOPE_ALIASES } from '../src/auth/scopes.js';
 
 // ---------------------------------------------------------------------------
 // Helpers — save & restore env vars around each test
@@ -17,6 +19,8 @@ const EXTERNAL_VARS = [
   'GOOGLE_DRIVE_MCP_CLIENT_ID',
   'GOOGLE_DRIVE_MCP_CLIENT_SECRET',
   'GOOGLE_APPLICATION_CREDENTIALS',
+  'GOOGLE_DRIVE_MCP_SUBJECT',
+  'GOOGLE_DRIVE_MCP_SCOPES',
 ] as const;
 
 function clearExternalEnv() {
@@ -64,6 +68,64 @@ test('isServiceAccountMode returns true when GOOGLE_APPLICATION_CREDENTIALS is s
 test('isServiceAccountMode returns false when not set', withEnv(
   {},
   () => { assert.equal(isServiceAccountMode(), false); },
+));
+
+// ---------------------------------------------------------------------------
+// buildServiceAccountAuthOptions
+// ---------------------------------------------------------------------------
+test('buildServiceAccountAuthOptions returns keyFile + default scopes when only GOOGLE_APPLICATION_CREDENTIALS is set', withEnv(
+  { GOOGLE_APPLICATION_CREDENTIALS: '/tmp/sa-key.json' },
+  () => {
+    const opts = buildServiceAccountAuthOptions();
+    assert.equal(opts.keyFile, '/tmp/sa-key.json');
+    assert.ok(Array.isArray(opts.scopes), 'scopes should be an array');
+    assert.ok((opts.scopes as string[]).length > 0, 'default scopes should be non-empty');
+    assert.equal(opts.clientOptions, undefined, 'clientOptions must be omitted when no subject is set');
+  },
+));
+
+test('buildServiceAccountAuthOptions sets clientOptions.subject for domain-wide delegation', withEnv(
+  {
+    GOOGLE_APPLICATION_CREDENTIALS: '/tmp/sa-key.json',
+    GOOGLE_DRIVE_MCP_SUBJECT: 'bot@example.com',
+  },
+  () => {
+    const opts = buildServiceAccountAuthOptions();
+    assert.deepEqual(opts.clientOptions, { subject: 'bot@example.com' });
+  },
+));
+
+test('buildServiceAccountAuthOptions trims whitespace around the subject', withEnv(
+  {
+    GOOGLE_APPLICATION_CREDENTIALS: '/tmp/sa-key.json',
+    GOOGLE_DRIVE_MCP_SUBJECT: '  bot@example.com  ',
+  },
+  () => {
+    const opts = buildServiceAccountAuthOptions();
+    assert.deepEqual(opts.clientOptions, { subject: 'bot@example.com' });
+  },
+));
+
+test('buildServiceAccountAuthOptions omits clientOptions when GOOGLE_DRIVE_MCP_SUBJECT is blank', withEnv(
+  {
+    GOOGLE_APPLICATION_CREDENTIALS: '/tmp/sa-key.json',
+    GOOGLE_DRIVE_MCP_SUBJECT: '   ',
+  },
+  () => {
+    const opts = buildServiceAccountAuthOptions();
+    assert.equal(opts.clientOptions, undefined);
+  },
+));
+
+test('buildServiceAccountAuthOptions honors GOOGLE_DRIVE_MCP_SCOPES', withEnv(
+  {
+    GOOGLE_APPLICATION_CREDENTIALS: '/tmp/sa-key.json',
+    GOOGLE_DRIVE_MCP_SCOPES: 'drive.file,documents',
+  },
+  () => {
+    const opts = buildServiceAccountAuthOptions();
+    assert.deepEqual(opts.scopes, [SCOPE_ALIASES['drive.file'], SCOPE_ALIASES['documents']]);
+  },
 ));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add Workspace domain-wide delegation (DWD) to service-account mode so an admin-authorized SA can act *as a specific user* — not just as itself.

Concretely:

- Read `GOOGLE_DRIVE_MCP_SUBJECT` and pass it as `clientOptions.subject` to `GoogleAuth`. This is the documented DWD impersonation path for JWT-based auth: https://developers.google.com/workspace/guides/create-credentials#service-account
- Honor `GOOGLE_DRIVE_MCP_SCOPES` in SA mode too (previously only the interactive OAuth path used it), so admins can narrow the JWT to a subset of the authorized scopes.
- Extract `buildServiceAccountAuthOptions()` so the subject + scopes resolution can be unit-tested without touching the filesystem.

## Why

Some Google APIs refuse requests from a pure service-account identity — Drive reads scoped to a user's "My Drive", Calendar ACL writes against a personal calendar, Docs created in a specific user's namespace, etc. DWD is the supported way around this: the Workspace admin grants the SA's client ID permission to impersonate users under specific scopes, and the SA mints JWTs with `sub=<user>` to act as them.

Before this change the MCP required OAuth refresh tokens for user-identity workflows, which forces operators to attach a personal Google account to every deployment. With `GOOGLE_DRIVE_MCP_SUBJECT` they can instead stand up a dedicated bot seat, delegate the SA to impersonate it, and drop in a single SA key.

## Behavior

- `GOOGLE_APPLICATION_CREDENTIALS` alone → unchanged (SA acts as itself).
- `GOOGLE_APPLICATION_CREDENTIALS` + `GOOGLE_DRIVE_MCP_SUBJECT=user@example.com` → SA impersonates that user. Workspace admin must authorize the SA's client ID for the requested scopes under Security → API controls → Manage Domain-wide Delegation. A startup log line now notes the impersonation target so operators can confirm which identity is being used.
- `GOOGLE_DRIVE_MCP_SCOPES` → resolved the same way as in OAuth mode (aliases + full URLs).

## Test plan

- [x] `npm run build` passes (tsc + bundle)
- [x] `npm test` passes — 279/279 tests, 18/18 in `external-auth.test.ts`
- [x] Five new unit tests for `buildServiceAccountAuthOptions`: default scopes, subject present, whitespace-trimmed subject, blank subject omitted, `GOOGLE_DRIVE_MCP_SCOPES` override
- [ ] End-to-end: verified locally against a Workspace tenant (tpm-agent@ bot seat, drive.file + documents + spreadsheets + presentations scopes) — can attach a session transcript if useful

## Notes

- Fully backwards compatible. Existing SA-mode deployments with no `GOOGLE_DRIVE_MCP_SUBJECT` set behave identically.
- Help text in `src/index.ts` updated to document both new env vars.
- Happy to adjust the env-var name if you'd prefer a different prefix (e.g. `GOOGLE_DRIVE_MCP_IMPERSONATE`).