### PR TITLE
fix(auth): HTML-escape dynamic content in OAuth callback responses

### DIFF
--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -8,6 +8,17 @@ import { resolveOAuthScopes } from './scopes.js';
 
 const SCOPES = resolveOAuthScopes();
 
+// Escape user-influenced strings before embedding them in HTML responses.
+// Covers both element content and double-quoted attribute contexts.
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export class AuthServer {
   private baseOAuth2Client: OAuth2Client; // Used by TokenManager for validation/refresh
   private flowOAuth2Client: OAuth2Client | null = null; // Used specifically for the auth code flow
@@ -41,7 +52,7 @@ export class AuthServer {
         scope: SCOPES,
         prompt: 'consent'
       });
-      res.send(`<h1>Google Drive Authentication</h1><a href="${authUrl}">Authenticate with Google</a>`);
+      res.send(`<h1>Google Drive Authentication</h1><a href="${escapeHtml(authUrl)}">Authenticate with Google</a>`);
     });
 
     this.app.get('/oauth2callback', async (req, res) => {
@@ -84,7 +95,7 @@ export class AuthServer {
               <div class="container">
                   <h1>Authentication Successful!</h1>
                   <p>Your authentication tokens have been saved successfully to:</p>
-                  <p><code>${tokenPath}</code></p>
+                  <p><code>${escapeHtml(tokenPath)}</code></p>
                   <p>You can now close this browser window.</p>
               </div>
           </body>
@@ -112,7 +123,7 @@ export class AuthServer {
               <div class="container">
                   <h1>Authentication Failed</h1>
                   <p>An error occurred during authentication:</p>
-                  <p><code>${message}</code></p>
+                  <p><code>${escapeHtml(message)}</code></p>
                   <p>Please try again or check the server logs.</p>
               </div>
           </body>


### PR DESCRIPTION
## Summary

The Express OAuth callback server in `src/auth/server.ts` interpolates three dynamic values directly into HTML response bodies without escaping:

- `${authUrl}` in the root route's `<a href="...">` attribute
- `${tokenPath}` in the success page
- `${message}` in the error page

## Why this matters

The `${message}` site is the most concerning. It is reached when `flowOAuth2Client.getToken(code)` throws, and the resulting error message may surface portions of the attacker-controllable `code=` query parameter (or other values that get incorporated into the thrown error). If so, raw HTML lands unescaped in the response.

Impact is bounded — the auth server only runs during the OAuth flow on ports 3000-3004 — but tightening this is cheap defense in depth.

## Change

Adds a small `escapeHtml` helper and applies it at all three interpolation sites for consistency. The `${authUrl}` and `${tokenPath}` sites are not currently attacker-influenced, but the escape is cheap and protects against regressions if the source of those values changes later (e.g., a custom env-var-driven token path becoming derived from user input).

```ts
function escapeHtml(s: string): string {
  return s
    .replace(/&/g, '&amp;')
    .replace(/</g, '&lt;')
    .replace(/>/g, '&gt;')
    .replace(/"/g, '&quot;')
    .replace(/'/g, '&#39;');
}
```

## Test plan

- [x] `npm run lint` — clean (typecheck + ESLint)
- [x] `npm test` — 279/279 tests pass, 0 failures
- [ ] Manual end-to-end OAuth flow — I did not run a live OAuth round-trip with this patch. Would appreciate the maintainer verifying nothing visual regressed in the success/error pages.

Happy to narrow the scope (e.g., escape only `${message}`) or rework the approach if you'd prefer.