### PR TITLE
fix(auth): bind OAuth callback server to 127.0.0.1 instead of all interfaces

### DIFF
--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -174,8 +174,12 @@ export class AuthServer {
     for (let port = this.portRange.start; port <= this.portRange.end; port++) {
       try {
         await new Promise<void>((resolve, reject) => {
-          // Create a temporary server instance to test the port
-          const testServer = this.app.listen(port, () => {
+          // Create a temporary server instance to test the port.
+          // Bind to the loopback interface explicitly: the OAuth redirect URI
+          // is hard-coded to `http://localhost:<port>/oauth2callback`, so we
+          // never need to accept connections from other interfaces, and doing
+          // so would expose the short-lived auth server to the LAN.
+          const testServer = this.app.listen(port, '127.0.0.1', () => {
             this.server = testServer; // Assign to class property *only* if successful
             console.error(`Authentication server listening on http://localhost:${port}`);
             resolve();


### PR DESCRIPTION
## Summary

In `src/auth/server.ts`, `startServerOnAvailablePort` creates the auth callback server with:

```ts
const testServer = this.app.listen(port, () => { ... });
```

Omitting the host argument makes Node default to `::` / `0.0.0.0`, so the server accepts connections from every network interface — not just loopback.

## Why this matters

The OAuth redirect URI is hard-coded to `http://localhost:<port>/oauth2callback`, so Google only ever redirects via loopback, and the only legitimate client of this endpoint is a browser on the same host. There's no reason to listen on external interfaces.

During the (short) OAuth flow window, any device on the same LAN can hit `http://<host-ip>:300{0..4}/oauth2callback?code=...`. That's a small but real attack surface — both because of error-handling edge cases (e.g. the unescaped error-page interpolation in #116) and because future maintenance of the callback handler shouldn't have to assume LAN-untrusted input.

## Change

One-line behavior change: pass `'127.0.0.1'` as the explicit host to `listen()`, with a comment explaining why.

```diff
- const testServer = this.app.listen(port, () => {
+ const testServer = this.app.listen(port, '127.0.0.1', () => {
```

## Compatibility note for users

Anyone currently running the MCP on a different machine than the browser that completes auth (uncommon setup) will need to use SSH port-forwarding — e.g. `ssh -L 3000:localhost:3000 user@host`. Forwarded connections appear to the listener as originating from 127.0.0.1, so they work with the new bind without any further changes. The existing `GOOGLE_DRIVE_MCP_AUTH_PORT` env var continues to work as before.

If you'd prefer to add an explicit env-var escape hatch (e.g. `GOOGLE_DRIVE_MCP_AUTH_HOST`) for the rare cases that genuinely need non-loopback binding, happy to follow up — I went with the smaller patch to keep the change focused.

## Test plan

- [x] `npm test` — 279/279 tests pass
- [ ] Manual end-to-end OAuth flow — not run with this patch; loopback bind is the standard pattern but would appreciate the maintainer confirming the flow still completes cleanly in the typical "MCP and browser on the same Mac" setup.

Independent of #116 (escape-HTML PR) — both target this same file but different sections, so order of merge shouldn't matter.