### PR TITLE
docs(auth): document domain-wide delegation; drop clientOptions cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **auth:** support Workspace domain-wide delegation via `GOOGLE_DRIVE_MCP_SUBJECT`; `GOOGLE_DRIVE_MCP_SCOPES` is now honored in service-account mode ([#107](https://github.com/piotr-agier/google-drive-mcp/pull/107))
+
 ## [2.2.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.1.0...v2.2.0) (2026-04-20)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -972,6 +972,29 @@ Set the standard `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point 
 
 **Note:** The service account must have access to the Google Drive files/folders you want to work with. For Shared Drives, grant the service account's email address the appropriate permissions.
 
+#### Domain-Wide Delegation (impersonating a user)
+
+By default a service account acts as itself. Some Google APIs (for example Drive reads scoped to a user's "My Drive", or Calendar ACL writes against a personal calendar) require acting as a real Workspace user. Set `GOOGLE_DRIVE_MCP_SUBJECT` to the email of the user to impersonate:
+
+```json
+{
+  "mcpServers": {
+    "google-drive": {
+      "command": "npx",
+      "args": ["@piotr-agier/google-drive-mcp"],
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/service-account-key.json",
+        "GOOGLE_DRIVE_MCP_SUBJECT": "user@your-domain.com"
+      }
+    }
+  }
+}
+```
+
+**Prerequisite:** a Workspace admin must authorize the service account's client ID for the requested scopes under **Admin console > Security > API controls > Manage Domain-wide Delegation**. The scopes granted there must cover the scopes the server requests (see [OAuth Scope Configuration](#oauth-scope-configuration)).
+
+`GOOGLE_DRIVE_MCP_SCOPES` applies in service-account mode too, so you can narrow the JWT to a subset of the delegated scopes.
+
 ### 2. External OAuth Token Mode
 
 Provide a pre-obtained OAuth access token via `GOOGLE_DRIVE_MCP_ACCESS_TOKEN`. This is useful when an external service handles the OAuth flow (e.g., a web app that obtains tokens on behalf of the user).
@@ -1329,6 +1352,7 @@ npm run typecheck # Type checking without compilation
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON key file | `/path/to/service-account.json` |
+| `GOOGLE_DRIVE_MCP_SUBJECT` | Workspace user to impersonate via domain-wide delegation (optional, service account mode) | `user@your-domain.com` |
 | `GOOGLE_DRIVE_MCP_ACCESS_TOKEN` | Pre-obtained OAuth access token | `ya29.a0AfH6SM...` |
 | `GOOGLE_DRIVE_MCP_REFRESH_TOKEN` | Refresh token for auto-refresh (optional) | `1//0dx...` |
 | `GOOGLE_DRIVE_MCP_CLIENT_ID` | OAuth client ID (required with refresh token) | `123456789.apps.googleusercontent.com` |

--- a/src/auth/externalAuth.ts
+++ b/src/auth/externalAuth.ts
@@ -51,7 +51,7 @@ export function buildServiceAccountAuthOptions(): GoogleAuthOptions {
  */
 export async function createServiceAccountAuth(): Promise<any> {
   const options = buildServiceAccountAuthOptions();
-  const subject = (options.clientOptions as { subject?: string } | undefined)?.subject;
+  const subject = process.env.GOOGLE_DRIVE_MCP_SUBJECT?.trim();
   console.error(
     `Using service account credentials from ${options.keyFile}` +
       (subject ? ` (impersonating ${subject} via domain-wide delegation)` : ''),

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,6 +394,9 @@ Environment Variables:
   GOOGLE_DRIVE_MCP_TOKEN_PATH           Path to store authentication tokens
   GOOGLE_DRIVE_MCP_AUTH_PORT            Starting port for OAuth callback server (default: 3000, uses 5 consecutive ports)
 
+  Common Configuration:
+  GOOGLE_DRIVE_MCP_SCOPES               Comma-separated scopes to request (aliases or full URLs; defaults to all Drive/Docs/Sheets/Slides/Calendar scopes). Applies to local OAuth, external OAuth, and service account modes.
+
   Transport Configuration:
   MCP_TRANSPORT                         Transport mode: stdio or http (default: stdio)
   MCP_HTTP_PORT                         HTTP listen port (default: 3100)
@@ -402,7 +405,6 @@ Environment Variables:
   Service Account Mode:
   GOOGLE_APPLICATION_CREDENTIALS        Path to service account JSON key file
   GOOGLE_DRIVE_MCP_SUBJECT              Workspace user to impersonate via domain-wide delegation (optional)
-  GOOGLE_DRIVE_MCP_SCOPES               Comma-separated scopes to request (aliases or full URLs; defaults to all Drive/Docs/Sheets/Slides/Calendar scopes)
 
   External OAuth Token Mode:
   GOOGLE_DRIVE_MCP_ACCESS_TOKEN         Pre-obtained Google OAuth access token


### PR DESCRIPTION
## Summary

Addresses the four review follow-ups from #107, which was merged as-is. No behavior change beyond docs and one readability fix.

- **CHANGELOG**: add an `[Unreleased]` Features entry for `GOOGLE_DRIVE_MCP_SUBJECT` and the newly-honored `GOOGLE_DRIVE_MCP_SCOPES` in service-account mode.
- **README**: document domain-wide delegation in the Service Account Mode section, including the Workspace admin prerequisite (Manage Domain-wide Delegation) and a worked `env` example; add a `GOOGLE_DRIVE_MCP_SUBJECT` row to the external-auth env var table.
- **`--help`**: move `GOOGLE_DRIVE_MCP_SCOPES` out of "Service Account Mode" into a new "Common Configuration" block, since it also drives the local and external OAuth paths (`src/auth/server.ts`, `src/tools/drive.ts`).
- **`externalAuth.ts`**: in `createServiceAccountAuth`, re-read `process.env.GOOGLE_DRIVE_MCP_SUBJECT?.trim()` for the log line instead of casting `options.clientOptions` back open. The log path no longer depends on the internal shape of `GoogleAuthOptions`.

The subject-format-validation suggestion from the review was intentionally not actioned (weak `includes('@')` check, decipherable Google-side error).

## Test plan

- [x] `npm run build` passes (tsc + bundle)
- [x] `npm test` passes (279/279)

🤖 Generated with [Claude Code](https://claude.com/claude-code)