### PR TITLE
feat(docs): add paginated Google Doc reading tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,18 +583,18 @@ When binding to `127.0.0.1` (default), DNS rebinding protection is automatically
   - `documentId`: Document ID
   - `format`: Output format — `text` or `markdown` (optional, default: text)
   - `offset`: Character offset into the output text (optional, default: 0; pass the previous response's `nextOffset`)
-  - `limit`: Maximum characters per page (optional, default: 50000, max: 100000)
+  - `limit`: Maximum characters per page (optional, default: 50000, max: 80000)
   - `tabId`: Read a specific tab by ID (optional)
 
 - **getGoogleDocContent** - Get document content with text indices for formatting
   - `documentId`: Document ID
   - `includeFormatting`: Include font, style, and color info for each text span (optional, default: false)
 
-- **getGoogleDocContentPaginated** - Paginated `getGoogleDocContent`; page ends snap to a line boundary so `[start-end]` index prefixes are never split
+- **getGoogleDocContentPaginated** - Paginated `getGoogleDocContent`; page ends snap to a line boundary where possible (a single line longer than `limit` is hard-cut to make forward progress)
   - `documentId`: Document ID
   - `includeFormatting`: Include font, style, and color info for each text span (optional, default: false)
   - `offset`: Character offset into the formatted output (optional, default: 0; pass the previous response's `nextOffset`)
-  - `limit`: Maximum characters per page (optional, default: 50000, max: 100000)
+  - `limit`: Maximum characters per page (optional, default: 50000, max: 80000)
 
 - **listDocumentTabs** - List all tabs in a Google Doc with their IDs and hierarchy
   - `documentId`: Document ID

--- a/README.md
+++ b/README.md
@@ -579,9 +579,22 @@ When binding to `127.0.0.1` (default), DNS rebinding protection is automatically
   - `format`: Output format — `text`, `json`, or `markdown` (optional, default: text)
   - `maxLength`: Maximum characters to return (optional)
 
+- **readGoogleDocPaginated** - Read a large Google Doc one page at a time (avoids host output-size truncation)
+  - `documentId`: Document ID
+  - `format`: Output format — `text` or `markdown` (optional, default: text)
+  - `offset`: Character offset into the output text (optional, default: 0; pass the previous response's `nextOffset`)
+  - `limit`: Maximum characters per page (optional, default: 50000, max: 100000)
+  - `tabId`: Read a specific tab by ID (optional)
+
 - **getGoogleDocContent** - Get document content with text indices for formatting
   - `documentId`: Document ID
   - `includeFormatting`: Include font, style, and color info for each text span (optional, default: false)
+
+- **getGoogleDocContentPaginated** - Paginated `getGoogleDocContent`; page ends snap to a line boundary so `[start-end]` index prefixes are never split
+  - `documentId`: Document ID
+  - `includeFormatting`: Include font, style, and color info for each text span (optional, default: false)
+  - `offset`: Character offset into the formatted output (optional, default: 0; pass the previous response's `nextOffset`)
+  - `limit`: Maximum characters per page (optional, default: 50000, max: 100000)
 
 - **listDocumentTabs** - List all tabs in a Google Doc with their IDs and hierarchy
   - `documentId`: Document ID

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1084,7 +1084,7 @@ const ReadGoogleDocPaginatedSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
   format: z.enum(['text', 'markdown']).optional().default('text'),
   offset: z.number().int().min(0).optional().default(0),
-  limit: z.number().int().min(1).max(100000).optional().default(50000),
+  limit: z.number().int().min(1).max(80000).optional().default(50000),
   tabId: z.string().optional()
 });
 
@@ -1092,7 +1092,7 @@ const GetGoogleDocContentPaginatedSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
   includeFormatting: z.boolean().optional(),
   offset: z.number().int().min(0).optional().default(0),
-  limit: z.number().int().min(1).max(100000).optional().default(50000),
+  limit: z.number().int().min(1).max(80000).optional().default(50000),
 });
 
 const ListDocumentTabsSchema = z.object({
@@ -1357,7 +1357,7 @@ export const toolDefinitions: ToolDefinition[] = [
         documentId: { type: "string", description: "The document ID" },
         format: { type: "string", enum: ["text", "markdown"], description: "Output format (default: text)" },
         offset: { type: "number", description: "Character offset into the output text, not raw doc characters (with format=markdown the title prefix counts). 0-based, default: 0. Pass the previous response's nextOffset to get the following page." },
-        limit: { type: "number", description: "Maximum characters to return per page (default: 50000, max: 100000; the gap below the host's ~100K limit leaves room for the JSON response envelope)" },
+        limit: { type: "number", description: "Maximum characters to return per page (default: 50000, max: 80000; kept below the host's ~100K output cap to leave room for the JSON envelope and newline escaping)" },
         tabId: { type: "string", description: "Read a specific tab by ID (from listDocumentTabs). If omitted, all tabs are returned." }
       },
       required: ["documentId"]
@@ -1588,7 +1588,7 @@ export const toolDefinitions: ToolDefinition[] = [
         documentId: { type: "string", description: "Document ID" },
         includeFormatting: { type: "boolean", description: "Include font, style, and color info for each text span (default: false)" },
         offset: { type: "number", description: "Character offset into the formatted indexed output (not raw doc characters). 0-based, default: 0. Pass the previous response's nextOffset to get the following page." },
-        limit: { type: "number", description: "Maximum characters to return per page (default: 50000, max: 100000; the gap below the host's ~100K limit leaves room for the JSON response envelope). The page end is snapped back to a line boundary so [start-end] index prefixes are never split." }
+        limit: { type: "number", description: "Maximum characters to return per page (default: 50000, max: 80000; kept below the host's ~100K output cap to leave room for the JSON envelope and newline escaping). The page end is snapped back to a line boundary where possible; a single line longer than limit is hard-cut to guarantee forward progress." }
       },
       required: ["documentId"]
     }

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -811,6 +811,19 @@ function buildDocFormattedContent(
   return { formattedContent, totalLength };
 }
 
+// Slice [offset, offset+limit) but snap the end back to a line boundary so a
+// structural line prefix (e.g. "[start-end] ...") is never cut mid-line.
+// When a single line is longer than `limit` no newline exists in the window;
+// keep the hard cut so pagination always makes forward progress.
+function sliceByLine(content: string, offset: number, limit: number): { slice: string; end: number } {
+  let end = Math.min(offset + limit, content.length);
+  if (end < content.length) {
+    const nl = content.lastIndexOf('\n', end);
+    if (nl > offset) end = nl + 1;
+  }
+  return { slice: content.slice(offset, end), end };
+}
+
 /**
  * Parse a DOCX export to extract comment positions and surrounding context.
  * Returns DOCX comment metadata and context maps keyed by DOCX comment ID.
@@ -1069,7 +1082,7 @@ const ReadGoogleDocSchema = z.object({
 
 const ReadGoogleDocPaginatedSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
-  format: z.enum(['text', 'json', 'markdown']).optional().default('text'),
+  format: z.enum(['text', 'markdown']).optional().default('text'),
   offset: z.number().int().min(0).optional().default(0),
   limit: z.number().int().min(1).max(100000).optional().default(50000),
   tabId: z.string().optional()
@@ -1342,9 +1355,9 @@ export const toolDefinitions: ToolDefinition[] = [
       type: "object",
       properties: {
         documentId: { type: "string", description: "The document ID" },
-        format: { type: "string", enum: ["text", "json", "markdown"], description: "Output format (default: text)" },
-        offset: { type: "number", description: "Character offset to start reading from (0-based, default: 0)" },
-        limit: { type: "number", description: "Maximum characters to return (default: 50000, max: 100000)" },
+        format: { type: "string", enum: ["text", "markdown"], description: "Output format (default: text)" },
+        offset: { type: "number", description: "Character offset into the output text, not raw doc characters (with format=markdown the title prefix counts). 0-based, default: 0. Pass the previous response's nextOffset to get the following page." },
+        limit: { type: "number", description: "Maximum characters to return per page (default: 50000, max: 100000; the gap below the host's ~100K limit leaves room for the JSON response envelope)" },
         tabId: { type: "string", description: "Read a specific tab by ID (from listDocumentTabs). If omitted, all tabs are returned." }
       },
       required: ["documentId"]
@@ -1574,8 +1587,8 @@ export const toolDefinitions: ToolDefinition[] = [
       properties: {
         documentId: { type: "string", description: "Document ID" },
         includeFormatting: { type: "boolean", description: "Include font, style, and color info for each text span (default: false)" },
-        offset: { type: "number", description: "Character offset to start reading from (0-based, default: 0)" },
-        limit: { type: "number", description: "Maximum characters to return (default: 50000, max: 100000)" }
+        offset: { type: "number", description: "Character offset into the formatted indexed output (not raw doc characters). 0-based, default: 0. Pass the previous response's nextOffset to get the following page." },
+        limit: { type: "number", description: "Maximum characters to return per page (default: 50000, max: 100000; the gap below the host's ~100K limit leaves room for the JSON response envelope). The page end is snapped back to a line boundary so [start-end] index prefixes are never split." }
       },
       required: ["documentId"]
     }
@@ -1987,14 +2000,15 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
 
       const offset = a.offset;
       const limit = a.limit;
-      const slicedContent = formattedContent.slice(offset, offset + limit);
-      const hasMore = offset + limit < formattedContent.length;
+      const { slice: slicedContent, end } = sliceByLine(formattedContent, offset, limit);
+      const hasMore = end < formattedContent.length;
 
       const result = {
-        totalLength: formattedContent.length,
-        docTotalLength: totalLength,
+        outputLength: formattedContent.length,
+        documentLength: totalLength,
         offset,
         limit,
+        nextOffset: end,
         hasMore,
         content: slicedContent,
       };
@@ -2146,13 +2160,15 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
 
       const offset = a.offset;
       const limit = a.limit;
-      const slicedText = fullText.slice(offset, offset + limit);
-      const hasMore = offset + limit < fullText.length;
+      const { slice: slicedText, end } = sliceByLine(fullText, offset, limit);
+      const hasMore = end < fullText.length;
 
       const result = {
-        totalLength: fullText.length,
+        outputLength: fullText.length,
+        documentLength: text.length,
         offset,
         limit,
+        nextOffset: end,
         hasMore,
         content: slicedText,
       };

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -1326,6 +1326,147 @@ describe('Docs tools', () => {
     });
   });
 
+  // --- readGoogleDocPaginated ---
+  describe('readGoogleDocPaginated', () => {
+    const longDoc = (text: string) => ({
+      documentId: 'doc-1', title: 'Big Doc',
+      body: { content: [{ paragraph: { elements: [{ textRun: { content: text } }] } }] },
+    });
+
+    it('returns first page with hasMore and nextOffset', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: longDoc('X'.repeat(120)) }));
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', offset: 0, limit: 50 });
+      assert.equal(res.isError, false);
+      const r = JSON.parse(res.content[0].text);
+      assert.equal(r.content.length, 50);
+      assert.equal(r.outputLength, 120);
+      assert.equal(r.documentLength, 120);
+      assert.equal(r.hasMore, true);
+      assert.equal(r.nextOffset, 50);
+    });
+
+    it('last page reports hasMore false and nextOffset at end', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: longDoc('Y'.repeat(40)) }));
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', offset: 0, limit: 50000 });
+      const r = JSON.parse(res.content[0].text);
+      assert.equal(r.content.length, 40);
+      assert.equal(r.hasMore, false);
+      assert.equal(r.nextOffset, 40);
+    });
+
+    it('offset beyond document returns empty content', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: longDoc('Z'.repeat(30)) }));
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', offset: 9999, limit: 50 });
+      const r = JSON.parse(res.content[0].text);
+      assert.equal(r.content, '');
+      assert.equal(r.hasMore, false);
+      assert.equal(r.nextOffset, 30);
+    });
+
+    it('markdown format includes the title in the first page', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: longDoc('Body text\n') }));
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', format: 'markdown', offset: 0, limit: 50000 });
+      const r = JSON.parse(res.content[0].text);
+      assert.ok(r.content.startsWith('# Big Doc'), 'first page should start with the markdown title');
+      assert.ok(r.outputLength > r.documentLength, 'outputLength includes the title prefix, documentLength does not');
+    });
+
+    it('reads a specific tab by tabId', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: mockDocs.multiTab() }));
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', tabId: 'tab-2', offset: 0, limit: 50000 });
+      const r = JSON.parse(res.content[0].text);
+      assert.ok(r.content.includes('Second tab'));
+      assert.ok(!r.content.includes('First tab'));
+    });
+
+    it('returns error for unknown tabId', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: mockDocs.multiTab() }));
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', tabId: 'nope' });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text.includes('not found'));
+    });
+
+    it('rejects the removed json format', async () => {
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', format: 'json' });
+      assert.equal(res.isError, true);
+    });
+
+    it('validation error when documentId missing', async () => {
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', {});
+      assert.equal(res.isError, true);
+    });
+  });
+
+  // --- getGoogleDocContentPaginated ---
+  describe('getGoogleDocContentPaginated', () => {
+    const indexedDoc = () => ({
+      documentId: 'doc-1', title: 'Indexed Doc',
+      body: { content: [
+        { paragraph: { elements: [{ textRun: { content: 'Alpha\n' }, startIndex: 1, endIndex: 7 }] } },
+        { paragraph: { elements: [{ textRun: { content: 'Bravo\n' }, startIndex: 7, endIndex: 13 }] } },
+        { paragraph: { elements: [{ textRun: { content: 'Charlie\n' }, startIndex: 13, endIndex: 21 }] } },
+      ] },
+    });
+    const oneLongLine = () => ({
+      documentId: 'doc-1', title: 'One Long Line',
+      body: { content: [{ paragraph: { elements: [{ textRun: { content: 'Q'.repeat(200) + '\n' }, startIndex: 1, endIndex: 202 }] } }] },
+    });
+
+    it('returns indexed content with hasMore and nextOffset', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: indexedDoc() }));
+      const res = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: 0, limit: 50000 });
+      assert.equal(res.isError, false);
+      const r = JSON.parse(res.content[0].text);
+      assert.ok(r.content.includes('[1-6] Alpha'));
+      assert.ok(r.content.includes('[7-12] Bravo'));
+      assert.equal(r.hasMore, false);
+      assert.equal(typeof r.outputLength, 'number');
+      assert.equal(typeof r.documentLength, 'number');
+    });
+
+    it('snaps the page end to a line boundary so index prefixes are never split', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: indexedDoc() }));
+      const page1 = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: 0, limit: 50 });
+      const r1 = JSON.parse(page1.content[0].text);
+      assert.ok(r1.content.endsWith('\n'), 'snapped page must end on a newline');
+      assert.ok(r1.content.includes('[1-6] Alpha'), 'the Alpha line must be whole');
+      assert.ok(!r1.content.includes('[7-12'), 'the Bravo prefix must not be partially included');
+      assert.equal(r1.hasMore, true);
+
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: indexedDoc() }));
+      const page2 = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: r1.nextOffset, limit: 50 });
+      const r2 = JSON.parse(page2.content[0].text);
+      assert.ok(r2.content.startsWith('[7-12] Bravo'), 'next page must start at a clean index prefix');
+    });
+
+    it('makes forward progress when a single line exceeds the limit', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: oneLongLine() }));
+      const page1 = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: 0, limit: 50 });
+      const r1 = JSON.parse(page1.content[0].text);
+
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: oneLongLine() }));
+      const page2 = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: r1.nextOffset, limit: 50 });
+      const r2 = JSON.parse(page2.content[0].text);
+      assert.ok(r2.nextOffset > r1.nextOffset, 'pagination must advance even with no newline in the window');
+      assert.ok(r2.content.length > 0, 'page must not be empty');
+      assert.equal(r2.hasMore, true);
+    });
+
+    it('offset beyond document returns empty content', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: indexedDoc() }));
+      const res = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: 999999, limit: 50 });
+      const r = JSON.parse(res.content[0].text);
+      assert.equal(r.content, '');
+      assert.equal(r.hasMore, false);
+      assert.equal(r.nextOffset, r.outputLength);
+    });
+
+    it('validation error when documentId missing', async () => {
+      const res = await callTool(ctx.client, 'getGoogleDocContentPaginated', {});
+      assert.equal(res.isError, true);
+    });
+  });
+
   describe('deleteComment', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'deleteComment', { documentId: 'doc-1', commentId: 'c1' });

--- a/test/schema/tool-registry.test.ts
+++ b/test/schema/tool-registry.test.ts
@@ -2,13 +2,13 @@ import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
 import { setupTestServer, type TestContext } from '../helpers/setup-server.js';
 
-const EXPECTED_TOOL_COUNT = 104;
+const EXPECTED_TOOL_COUNT = 106;
 
 const EXPECTED_TOOLS = [
   'search', 'createTextFile', 'updateTextFile', 'createFolder', 'listFolder', 'listSharedDrives',
   'deleteItem', 'renameItem', 'moveItem',
   'createGoogleDoc', 'updateGoogleDoc', 'insertText', 'deleteRange',
-  'readGoogleDoc', 'listDocumentTabs', 'applyTextStyle', 'applyParagraphStyle', 'formatGoogleDocText', 'formatGoogleDocParagraph', 'createParagraphBullets', 'findAndReplaceInDoc',
+  'readGoogleDoc', 'readGoogleDocPaginated', 'listDocumentTabs', 'applyTextStyle', 'applyParagraphStyle', 'formatGoogleDocText', 'formatGoogleDocParagraph', 'createParagraphBullets', 'findAndReplaceInDoc',
   'listComments', 'getComment', 'addComment', 'replyToComment', 'deleteComment',
   'createGoogleSheet', 'updateGoogleSheet', 'getGoogleSheetContent',
   'formatGoogleSheetCells', 'formatGoogleSheetText', 'formatGoogleSheetNumbers',
@@ -16,7 +16,7 @@ const EXPECTED_TOOLS = [
   'getSpreadsheetInfo', 'appendSpreadsheetRows', 'addSpreadsheetSheet', 'addSheet', 'listSheets', 'renameSheet', 'deleteSheet', 'addDataValidation', 'protectRange', 'addNamedRange',
   'listGoogleSheets', 'copyFile',
   'createGoogleSlides', 'updateGoogleSlides',
-  'getGoogleDocContent', 'getGoogleSlidesContent',
+  'getGoogleDocContent', 'getGoogleDocContentPaginated', 'getGoogleSlidesContent',
   'formatGoogleSlidesText', 'formatGoogleSlidesParagraph',
   'styleGoogleSlidesShape', 'setGoogleSlidesBackground',
   'createGoogleSlidesTextBox', 'createGoogleSlidesShape',


### PR DESCRIPTION
Follow-up to #112 (merged as `1b8664c`). That PR added `readGoogleDocPaginated`
and `getGoogleDocContentPaginated` but merged with a non-conventional commit, so
release-please never recorded the feature. This PR is typed `feat(docs)` so the
feature lands in the changelog, and it resolves the deferred review.

## Summary

- **Page boundaries snap to a line** — `sliceByLine` ensures `[start-end]`
  index prefixes are never split mid-token; both tools now return `nextOffset`,
  with a hard-cut fallback so pagination still advances on a line longer than
  `limit`. `hasMore` is derived from the snapped end.
- **Dropped unsupported `json` format** from `readGoogleDocPaginated` — it was
  advertised in the schema but silently returned plain text. Now rejected by
  validation.
- **Unified response fields** across both tools: `outputLength` +
  `documentLength` (previously `totalLength` / `docTotalLength`, which meant
  different things in each tool).
- **Fixed the tool-registry test** (104 → 106 + registered both names). This
  test was already red on `master` after #112.
- **Added integration tests** and documented `offset`/`limit` semantics in the
  tool schemas and README.

Deliberately out of scope (documented in the backlog triage): the per-page
in-memory cache, the shared-`extractDocText` `tabId` behavior change, and the
header-in-offset note.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full suite green: 292/292 (`npm test` after `npm run build`)
- [x] New cases cover pagination, `tabId`, `json` rejection, prefix-snap, and
  forward progress on an over-limit line

🤖 Generated with [Claude Code](https://claude.com/claude-code)