### PR TITLE
fix(docs): neutral createDocFromHTML description + folder-resolution test

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1302,7 +1302,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "createDocFromHTML",
-    description: "Create a Google Doc from HTML content. HTML tags are automatically converted to native Google Doc styles: <h1> → Heading 1, <h2> → Heading 2, <p> → Normal Text, <b> → bold, <i> → italic, <ul>/<ol> → lists, <table> → tables. This is the recommended way to create styled documents — it avoids the paragraph style inheritance bug where body text inherits heading styles.",
+    description: "Create a Google Doc from HTML content in a single Drive API call. HTML tags are converted to native Google Doc styles: <h1> → Heading 1, <h2> → Heading 2, <p> → Normal Text, <b> → bold, <i> → italic, <ul>/<ol> → lists, <table> → tables. Useful when you want native heading/list/table styling applied in one request instead of a createGoogleDoc call followed by per-paragraph formatGoogleDocParagraph requests.",
     inputSchema: {
       type: "object",
       properties: {

--- a/test/integration/docs-from-html.test.ts
+++ b/test/integration/docs-from-html.test.ts
@@ -78,4 +78,44 @@ describe('createDocFromHTML', () => {
     const res = await callTool(ctx.client, 'createDocFromHTML', { html: '<p>Hello</p>' });
     assert.equal(res.isError, true);
   });
+
+  it('resolves parentFolderId and scopes the duplicate check to it', async () => {
+    // checkFileExists builds: `name = '...' and '<folderId>' in parents and trashed = false`.
+    // Return empty only when the query targets folder-abc; a name collision in
+    // any *other* folder returns a hit — it must NOT trip the duplicate guard.
+    ctx.mocks.drive.service.files.list._setImpl(async (params: any) => {
+      if (typeof params.q === 'string' && params.q.includes("'folder-abc' in parents")) {
+        return { data: { files: [] } };
+      }
+      return {
+        data: {
+          files: [{ id: 'collision-elsewhere', name: 'Foldered Doc', mimeType: 'application/vnd.google-apps.document' }],
+        },
+      };
+    });
+    ctx.mocks.drive.service.files.create._setImpl(async () => ({
+      data: { id: 'html-doc-2', name: 'Foldered Doc', webViewLink: 'https://docs.google.com/html-doc-2' },
+    }));
+
+    const res = await callTool(ctx.client, 'createDocFromHTML', {
+      html: '<p>x</p>',
+      name: 'Foldered Doc',
+      parentFolderId: 'folder-abc',
+    });
+
+    // Collision in a different folder did not block creation.
+    assert.equal(res.isError, false);
+    assert.ok(res.content[0].text.includes('html-doc-2'));
+
+    // parentFolderId resolved (plain ID passthrough) and flowed into files.create.
+    const createArg = ctx.mocks.drive.tracker.getCalls('files.create').at(-1)!.args[0];
+    assert.deepEqual(createArg.requestBody.parents, ['folder-abc']);
+
+    // The duplicate-check files.list query was scoped to the resolved folder.
+    const listArg = ctx.mocks.drive.tracker.getCalls('files.list').at(-1)!.args[0];
+    assert.ok(
+      listArg.q.includes("'folder-abc' in parents"),
+      `files.list query not scoped to folder-abc: ${listArg.q}`,
+    );
+  });
 });


### PR DESCRIPTION
Follow-ups to #108 (`createDocFromHTML`), deferred from the 2026-05-15 review triage. Items 1 and 2 of the deferred list; item 3 (provenance) is intentionally out of scope here, item 4 (PR #108 description) is moot now that #108 is merged/closed.

## 1. Rewrite the tool description (schema change)

The merged description claimed `createDocFromHTML` was *"the recommended way to create styled documents"* and that paragraph-style inheritance is a *"bug"*. The tool description is the prompt the model routes on:

- A brand-new tool advertising itself as preferred over the battle-tested `createGoogleDoc` + `formatGoogleDocParagraph` path skews model selection on reputation it hasn't earned.
- Paragraph-style inheritance is documented, intentional Google Docs API behaviour, not a bug — asserting "bug" in the public schema bakes in a contestable claim.

Replaced with a neutral capability statement (single-call HTML→native-style conversion, useful when you want styling in one request).

## 2. Add a folder-resolution test (code change)

The existing `docs-from-html.test.ts` covered happy path, duplicate-name rejection, and the two validation errors, but never exercised `parentFolderId` — the most interesting branch (`resolveFolderId` → `requestBody.parents`, and `checkFileExists` scoped to the resolved folder).

New case asserts:

1. An explicit `parentFolderId` resolves (plain-ID passthrough) and flows into `files.create` `requestBody.parents`.
2. The duplicate check is scoped to that folder — a name collision in a *different* folder does **not** trip the guard.

## Verification

- `npm run build` clean
- Full suite **297/297 passing** (was 296; +1 for the new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)