### PR TITLE
chore: add .codex/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ Thumbs.db
 *.swp
 *.swo
 
+# Agent/tool config
+.codex/
+
 # Test coverage
 coverage/
 .nyc_output/


### PR DESCRIPTION
Ignores the untracked `.codex/` agent/tool config directory so it doesn't show up as untracked or get committed accidentally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)