### PR TITLE
fix(auth): use 127.0.0.1 instead of localhost for OAuth callback redirect URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - **auth:** support Workspace domain-wide delegation via `GOOGLE_DRIVE_MCP_SUBJECT`; `GOOGLE_DRIVE_MCP_SCOPES` is now honored in service-account mode ([#107](https://github.com/piotr-agier/google-drive-mcp/pull/107))
 
+### Bug Fixes
+
+- **auth:** use loopback IP `127.0.0.1` instead of `localhost` for the OAuth callback redirect URI, matching the IPv4-only callback-server bind so the redirect resolves to the bound address on dual-stack hosts ([#NNN](https://github.com/piotr-agier/google-drive-mcp/pull/NNN))
+
 ## [2.2.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.1.0...v2.2.0) (2026-04-20)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- **auth:** use loopback IP `127.0.0.1` instead of `localhost` for the OAuth callback redirect URI, matching the IPv4-only callback-server bind so the redirect resolves to the bound address on dual-stack hosts ([#NNN](https://github.com/piotr-agier/google-drive-mcp/pull/NNN))
+- **auth:** use loopback IP `127.0.0.1` instead of `localhost` for the OAuth callback redirect URI, matching the IPv4-only callback-server bind so the redirect resolves to the bound address on dual-stack hosts ([#124](https://github.com/piotr-agier/google-drive-mcp/pull/124))
 
 ## [2.2.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.1.0...v2.2.0) (2026-04-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- **auth:** use loopback IP `127.0.0.1` instead of `localhost` for the OAuth callback redirect URI, matching the IPv4-only callback-server bind so the redirect resolves to the bound address on dual-stack hosts ([#124](https://github.com/piotr-agier/google-drive-mcp/pull/124))
+- **auth:** use loopback IP `127.0.0.1` instead of `localhost` for the OAuth callback redirect URI, matching the IPv4-only callback-server bind so the redirect resolves to the bound address on dual-stack hosts ([#124](https://github.com/piotr-agier/google-drive-mcp/pull/124)). Desktop-app OAuth clients (the recommended type) are unaffected; "Web application" clients that registered a `http://localhost:<port>` redirect must re-register it as `http://127.0.0.1:<port>` or auth fails with `redirect_uri_mismatch` — see README Troubleshooting
 
 ## [2.2.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.1.0...v2.2.0) (2026-04-20)
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ export GOOGLE_DRIVE_MCP_AUTH_PORT=3100
 
 The server will try 5 consecutive ports starting from the configured value (e.g., 3100–3104).
 
+The callback server binds to the loopback interface and the OAuth redirect URI uses the loopback IP — `http://127.0.0.1:<port>/oauth2callback` (default range `127.0.0.1:3000`–`127.0.0.1:3004`). **Desktop app** OAuth clients (the recommended type — see [Create OAuth 2.0 Credentials](#4-create-oauth-20-credentials)) accept any loopback redirect automatically and need no action. If you instead use a **Web application** OAuth client, you must register `http://127.0.0.1:<port>/oauth2callback` for every port in the range as an authorized redirect URI in Google Cloud Console, or authentication fails with `redirect_uri_mismatch`.
+
 ### Token Storage
 
 Authentication tokens are stored securely following the XDG Base Directory specification:
@@ -1188,6 +1190,7 @@ OAuth credentials not found. Please provide credentials using one of these metho
 1. **Wrong credential type**: Must be "Desktop app", not "Web application"
 2. **Port blocked**: Ports 3000-3004 must be available (or custom range if `GOOGLE_DRIVE_MCP_AUTH_PORT` is set)
 3. **Test user not added**: Add your email in OAuth consent screen
+4. **`redirect_uri_mismatch` (Web application clients only)**: The callback redirect URI uses the loopback IP `http://127.0.0.1:<port>/oauth2callback`. Switch to a "Desktop app" client (recommended), or add `http://127.0.0.1:3000/oauth2callback` … `http://127.0.0.1:3004/oauth2callback` (plus any custom `GOOGLE_DRIVE_MCP_AUTH_PORT` range) as authorized redirect URIs
 
 **Solution:**
 ```bash

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -13,7 +13,7 @@ function parseCredentialsFile(keys: Record<string, unknown>): OAuthCredentials {
     return {
       client_id: keys.client_id as string,
       client_secret: keys.client_secret as string | undefined,
-      redirect_uris: (keys.redirect_uris as string[] | undefined) || ['http://localhost:3000/oauth2callback']
+      redirect_uris: (keys.redirect_uris as string[] | undefined) || ['http://127.0.0.1:3000/oauth2callback']
     };
   } else {
     throw new Error('Invalid credentials file format. Expected either "installed", "web" object or direct client_id field.');
@@ -75,7 +75,7 @@ export async function initializeOAuth2Client(): Promise<OAuth2Client> {
     return new OAuth2Client({
       clientId: credentials.client_id,
       clientSecret: credentials.client_secret || undefined,
-      redirectUri: credentials.redirect_uris?.[0] || 'http://localhost:3000/oauth2callback',
+      redirectUri: credentials.redirect_uris?.[0] || 'http://127.0.0.1:3000/oauth2callback',
     });
   } catch (error) {
     throw new Error(`Error loading OAuth keys: ${error instanceof Error ? error.message : error}`);

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -152,7 +152,7 @@ export class AuthServer {
       this.flowOAuth2Client = new OAuth2Client(
         client_id,
         client_secret || undefined,
-        `http://localhost:${port}/oauth2callback`
+        `http://127.0.0.1:${port}/oauth2callback`
       );
     } catch (error) {
         // Could not load credentials, cannot proceed with auth flow
@@ -187,12 +187,14 @@ export class AuthServer {
         await new Promise<void>((resolve, reject) => {
           // Create a temporary server instance to test the port.
           // Bind to the loopback interface explicitly: the OAuth redirect URI
-          // is hard-coded to `http://localhost:<port>/oauth2callback`, so we
+          // is hard-coded to `http://127.0.0.1:<port>/oauth2callback`, so we
           // never need to accept connections from other interfaces, and doing
-          // so would expose the short-lived auth server to the LAN.
+          // so would expose the short-lived auth server to the LAN. The IP is
+          // used (not `localhost`) so the bind and the redirect URI resolve to
+          // the same address on dual-stack hosts.
           const testServer = this.app.listen(port, '127.0.0.1', () => {
             this.server = testServer; // Assign to class property *only* if successful
-            console.error(`Authentication server listening on http://localhost:${port}`);
+            console.error(`Authentication server listening on http://127.0.0.1:${port}`);
             resolve();
           });
           testServer.on('error', (err: NodeJS.ErrnoException) => {
@@ -225,6 +227,16 @@ export class AuthServer {
       const address = this.server.address();
       if (typeof address === 'object' && address !== null) {
         return address.port;
+      }
+    }
+    return null;
+  }
+
+  public getServerAddress(): string | null {
+    if (this.server) {
+      const address = this.server.address();
+      if (typeof address === 'object' && address !== null) {
+        return address.address;
       }
     }
     return null;

--- a/test/auth-server-bind.test.ts
+++ b/test/auth-server-bind.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { OAuth2Client } from 'google-auth-library';
+
+import { AuthServer } from '../src/auth/server.js';
+
+// ---------------------------------------------------------------------------
+// Regression test for the OAuth callback-server loopback bind.
+//
+// The callback server MUST bind to the IPv4 loopback address 127.0.0.1, not
+// all interfaces (the historical default when no host is passed to
+// `listen()`). A regression here would silently re-expose the short-lived
+// auth server to the LAN with the whole suite still green, so this asserts
+// the bind address explicitly.
+//
+// `startServerOnAvailablePort()` is the private port-binding path. It does
+// NOT call `loadCredentials()` (only `start()` does), so no OAuth/credential
+// mocking is needed — a throwaway OAuth2Client satisfies the constructor and
+// is never dereferenced by the binder.
+// ---------------------------------------------------------------------------
+
+test('auth callback server binds to 127.0.0.1, not all interfaces', async () => {
+  // Use a high, uncommon port range to avoid colliding with the default
+  // 3000–3004 (dev servers, etc.). Restore the env var afterwards so it
+  // cannot leak into anything else running in this process.
+  const savedPort = process.env.GOOGLE_DRIVE_MCP_AUTH_PORT;
+  process.env.GOOGLE_DRIVE_MCP_AUTH_PORT = '45123';
+
+  const server = new AuthServer(new OAuth2Client());
+  try {
+    const boundPort = await (
+      server as unknown as {
+        startServerOnAvailablePort(): Promise<number | null>;
+      }
+    ).startServerOnAvailablePort();
+
+    assert.notEqual(boundPort, null, 'server should have bound to a port');
+
+    // The security invariant: bound to the IPv4 loopback address only.
+    assert.equal(
+      server.getServerAddress(),
+      '127.0.0.1',
+      'callback server must bind to 127.0.0.1, not 0.0.0.0/::',
+    );
+
+    // Port should be within the configured range (the binder auto-advances
+    // through 45123–45127 on EADDRINUSE, so assert membership, not equality).
+    const runningPort = server.getRunningPort();
+    assert.ok(
+      runningPort !== null && runningPort >= 45123 && runningPort <= 45127,
+      `running port ${runningPort} should be within 45123–45127`,
+    );
+    assert.equal(runningPort, boundPort);
+  } finally {
+    await server.stop();
+    if (savedPort === undefined) {
+      delete process.env.GOOGLE_DRIVE_MCP_AUTH_PORT;
+    } else {
+      process.env.GOOGLE_DRIVE_MCP_AUTH_PORT = savedPort;
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up to #117 (which bound the OAuth callback server to IPv4 `127.0.0.1`). The `redirect_uri` handed to Google was still `http://localhost:<port>/oauth2callback`, leaving the redirect inconsistent with the bind.

On dual-stack hosts (default macOS `/etc/hosts` maps `localhost` → both `127.0.0.1` and `::1`), `localhost` can resolve to `::1` first. The server only listens on IPv4 `127.0.0.1`, so the callback then depends entirely on browser Happy Eyeballs (RFC 8305) falling back from a refused `[::1]:port` to IPv4. Google's own OAuth 2.0 loopback guidance recommends the loopback **IP** over `localhost` for exactly this reason.

## Changes

- **`src/auth/server.ts`** — flow-client `redirect_uri` (load-bearing), the bind-rationale comment, and the stderr log → `http://127.0.0.1:<port>/oauth2callback`. Added `getServerAddress()`, symmetric with the existing `getRunningPort()`.
- **`src/auth/client.ts`** — the two fallback redirect defaults → `127.0.0.1`. These feed `baseOAuth2Client` (token validation/refresh) and are **off** the interactive redirect leg — consistency only.
- **`test/auth-server-bind.test.ts`** (new) — regression test asserting the callback server binds to `127.0.0.1` (not `0.0.0.0`/`::`). Without it, a revert to `listen(port, cb)` would silently re-expose the server LAN-wide with a green suite.
- **README / CHANGELOG** — documents the impact (see compatibility note).

## Compatibility note (important)

This is **safe and recommended for "Desktop app" OAuth clients** — the documented/recommended type for this project (RFC 8252 §7.3: native-app loopback redirects accept any loopback IP/port without registration).

For **"Web application" OAuth clients**, the `redirect_uri` must match a registered URI exactly. A user who registered `http://localhost:<port>/...` will now get `redirect_uri_mismatch` and must either switch to a Desktop-app client (recommended) or register the `http://127.0.0.1:3000..3004/oauth2callback` URIs. This is documented in the README (Auth Server Port section + Troubleshooting).

## Test plan

- [x] `npm run build` — typecheck/build pass
- [x] `npm test` — 297/297 pass (incl. the new bind regression test)
- [ ] Manual end-to-end OAuth flow — **not run** (requires a real Google account + browser; cannot be in CI). The `127.0.0.1` redirect switch is exactly where a `redirect_uri_mismatch` / IPv4-IPv6 issue would first surface, so worth confirming once on the standard "MCP + browser on the same Mac" setup with a Desktop-app client before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)