### PR TITLE
chore(test): make test:unit a glob so it stops drifting

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "prepare": "npm run build",
         "test": "npm run test:build && MCP_TESTING=1 node --test .tmp-test/test/**/*.test.js",
         "test:build": "shx rm -rf .tmp-test && tsc -p tsconfig.test.json && shx cp package.json .tmp-test/",
-        "test:unit": "npm run test:build && node --test .tmp-test/test/download-file.test.js .tmp-test/test/utils.test.js .tmp-test/test/comment-context.test.js",
+        "test:unit": "npm run test:build && MCP_TESTING=1 node --test .tmp-test/test/*.test.js",
         "test:integration": "npm run test:build && MCP_TESTING=1 node --test .tmp-test/test/integration/**/*.test.js .tmp-test/test/schema/**/*.test.js",
         "lint": "tsc --noEmit && eslint src/",
         "lint:types": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Deferred follow-up from the PR #123 review triage (recorded in the backlog at the time, not actioned in #123 to keep that PR scoped).

`test:unit` enumerated three test files by hand:

```
node --test .tmp-test/test/download-file.test.js .tmp-test/test/utils.test.js .tmp-test/test/comment-context.test.js
```

So newer top-level unit tests — `auth-escape-html` (added by #123), `external-auth`, `retry` — were **never run** by `test:unit`. They were only covered by the `npm test` glob, so CI stayed green and the gap was invisible to anyone running `test:unit` locally.

## Change

Replace the hand-list with a glob:

```
MCP_TESTING=1 node --test .tmp-test/test/*.test.js
```

- `*.test.js` matches **top-level only** — it is the exact complement of `test:integration` (`integration/**` + `schema/**`) and a subset of `test` (`**/*.test.js`). New top-level unit tests are picked up automatically; the curated list cannot drift again.
- `MCP_TESTING=1` added to match `test` and `test:integration` (both set it for the same files) and to guard the broader glob if a future top-level test imports the MCP server graph (auto-connect is gated on this env var — `src/index.ts:782`). It's a no-op for pure unit tests.

## Verification

- `npm run test:unit` → **94 tests, 94 pass, 0 fail, 0 cancelled** (was 3 hand-picked files). No hang/auto-connect.
- Glob resolves to exactly: `auth-escape-html`, `comment-context`, `download-file`, `external-auth`, `retry`, `utils`; `integration/` and `schema/` correctly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)