### PR TITLE
perf(docs): resolve tab-scoped applyParagraphStyle textToFind in one GET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 - **docs:** honor `tabId` in `insertTable`, `editTableCell`, `insertSmartChip`, `createFootnote`, `applyTextStyle`/`formatGoogleDocText`, `applyParagraphStyle`/`formatGoogleDocParagraph`, and `createParagraphBullets` — these previously ignored `tabId` and silently edited the default tab of multi-tab documents while reporting success ([#114](https://github.com/piotr-agier/google-drive-mcp/issues/114), [#126](https://github.com/piotr-agier/google-drive-mcp/pull/126))
 - **auth:** use loopback IP `127.0.0.1` instead of `localhost` for the OAuth callback redirect URI, matching the IPv4-only callback-server bind so the redirect resolves to the bound address on dual-stack hosts ([#124](https://github.com/piotr-agier/google-drive-mcp/pull/124)). Desktop-app OAuth clients (the recommended type) are unaffected; "Web application" clients that registered a `http://localhost:<port>` redirect must re-register it as `http://127.0.0.1:<port>` or auth fails with `redirect_uri_mismatch` — see README Troubleshooting
 
+### Performance Improvements
+
+- **docs:** `applyParagraphStyle` with `textToFind` + `tabId` now resolves the matched range and its enclosing paragraph from a single `documents.get`, instead of two full unmasked `includeTabsContent` fetches of the same document. The non-tab path is unchanged ([#114](https://github.com/piotr-agier/google-drive-mcp/issues/114))
+
 ## [2.2.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.1.0...v2.2.0) (2026-04-20)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Performance Improvements
 
-- **docs:** `applyParagraphStyle` with `textToFind` + `tabId` now resolves the matched range and its enclosing paragraph from a single `documents.get`, instead of two full unmasked `includeTabsContent` fetches of the same document. The non-tab path is unchanged ([#114](https://github.com/piotr-agier/google-drive-mcp/issues/114))
+- **docs:** `applyParagraphStyle` with `textToFind` + `tabId` now resolves the matched range and its enclosing paragraph from a single `documents.get`, instead of two full unmasked `includeTabsContent` fetches of the same document. The non-tab path is unchanged ([#114](https://github.com/piotr-agier/google-drive-mcp/issues/114), [#127](https://github.com/piotr-agier/google-drive-mcp/pull/127))
 
 ## [2.2.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.1.0...v2.2.0) (2026-04-20)
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -189,13 +189,18 @@ function withTab<T extends object>(target: T, tabId?: string): T & { tabId?: str
   return tabId ? { ...target, tabId } : target;
 }
 
-// Find text in a document and return the range indices
-async function findTextRange(ctx: ToolContext, documentId: string, textToFind: string, instance: number = 1, tabId?: string): Promise<{ startIndex: number; endIndex: number } | { error: string } | null> {
+// Find text in a document and return the range indices.
+// Pass `preResolvedContent` to reuse an already-fetched body content array
+// (e.g. a tab body resolved once by the caller) and skip the internal GET —
+// see applyParagraphStyle's tab-scoped textToFind path (#114 follow-up).
+async function findTextRange(ctx: ToolContext, documentId: string, textToFind: string, instance: number = 1, tabId?: string, preResolvedContent?: any[]): Promise<{ startIndex: number; endIndex: number } | { error: string } | null> {
   const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
 
   try {
     let content: any[];
-    if (tabId) {
+    if (preResolvedContent !== undefined) {
+      content = preResolvedContent;
+    } else if (tabId) {
       const resolved = await getTabBodyContent(ctx, documentId, tabId);
       if (resolved.error) return { error: resolved.error };
       content = resolved.content!;
@@ -293,13 +298,17 @@ async function findTextRange(ctx: ToolContext, documentId: string, textToFind: s
   }
 }
 
-// Get paragraph range containing a specific index
-async function getParagraphRange(ctx: ToolContext, documentId: string, indexWithin: number, tabId?: string): Promise<{ startIndex: number; endIndex: number } | { error: string } | null> {
+// Get paragraph range containing a specific index.
+// `preResolvedContent` works as in findTextRange: supply an already-fetched
+// body content array to skip the internal GET (#114 follow-up).
+async function getParagraphRange(ctx: ToolContext, documentId: string, indexWithin: number, tabId?: string, preResolvedContent?: any[]): Promise<{ startIndex: number; endIndex: number } | { error: string } | null> {
   const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
 
   try {
     let content: any[];
-    if (tabId) {
+    if (preResolvedContent !== undefined) {
+      content = preResolvedContent;
+    } else if (tabId) {
       const resolved = await getTabBodyContent(ctx, documentId, tabId);
       if (resolved.error) return { error: resolved.error };
       content = resolved.content!;
@@ -2485,12 +2494,27 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
         startIndex = a.startIndex;
         endIndex = a.endIndex;
       } else if (a.textToFind !== undefined) {
+        // Tab-scoped resolution needs an unmasked includeTabsContent fetch;
+        // resolve it once here and reuse it for both the text match and the
+        // enclosing-paragraph lookup instead of letting each helper fetch the
+        // whole document independently (#114 follow-up). The non-tab path
+        // keeps its two cheap narrow-field GETs unchanged.
+        let tabContent: any[] | undefined;
+        if (a.tabId) {
+          const resolved = await getTabBodyContent(ctx, a.documentId, a.tabId);
+          if (resolved.error) {
+            return errorResponse(resolved.error);
+          }
+          tabContent = resolved.content;
+        }
+
         const range = await findTextRange(
           ctx,
           a.documentId,
           a.textToFind,
           a.matchInstance || 1,
-          a.tabId
+          a.tabId,
+          tabContent
         );
         if (range && 'error' in range) {
           return errorResponse(range.error);
@@ -2499,7 +2523,7 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
           return errorResponse(`Text "${a.textToFind}" not found in document`);
         }
         // For paragraph style, get the full paragraph range
-        const paraRange = await getParagraphRange(ctx, a.documentId, range.startIndex, a.tabId);
+        const paraRange = await getParagraphRange(ctx, a.documentId, range.startIndex, a.tabId, tabContent);
         if (paraRange && 'error' in paraRange) {
           return errorResponse(paraRange.error);
         }

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -1778,6 +1778,44 @@ describe('Docs tools', () => {
         assert.equal(lastRequests()[0].updateParagraphStyle.range.tabId, 'tab-2');
         ctx.mocks.docs.service.documents.get._resetImpl();
       });
+
+      it('resolves tab-scoped textToFind with a single GET (#114 follow-up)', async () => {
+        ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+          data: { tabs: [
+            { tabProperties: { tabId: 'tab-2' }, documentTab: { body: { content: [
+              { startIndex: 1, endIndex: 14, paragraph: { elements: [{ textRun: { content: 'Find me here\n' }, startIndex: 1, endIndex: 14 }] } },
+            ] } } },
+          ] },
+        }));
+        const res = await callTool(ctx.client, 'applyParagraphStyle', { documentId: 'doc-1', textToFind: 'Find me', alignment: 'CENTER', tabId: 'tab-2' });
+        assert.equal(res.isError, false);
+        assert.ok(res.content[0].text.includes('in tab tab-2'));
+
+        // The whole point of the optimization: range + enclosing-paragraph
+        // resolution share one includeTabsContent fetch, not two.
+        const getCalls = ctx.mocks.docs.tracker.getCalls('documents.get');
+        assert.equal(getCalls.length, 1, 'tab-scoped textToFind must resolve from a single GET');
+        assert.equal(getCalls[0].args[0].includeTabsContent, true);
+
+        const range = lastRequests()[0].updateParagraphStyle.range;
+        assert.equal(range.tabId, 'tab-2');
+        assert.equal(range.startIndex, 1);
+        assert.equal(range.endIndex, 14);
+        ctx.mocks.docs.service.documents.get._resetImpl();
+      });
+
+      it('returns the standard not-found error and issues no batchUpdate for an unknown tabId (textToFind)', async () => {
+        ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+          data: { tabs: [{ tabProperties: { tabId: 'tab-1' }, documentTab: { body: { content: [] } } }] },
+        }));
+        const before = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length;
+        const res = await callTool(ctx.client, 'applyParagraphStyle', { documentId: 'doc-1', textToFind: 'x', alignment: 'CENTER', tabId: 'missing' });
+        assert.equal(res.isError, true);
+        assert.ok(res.content[0].text.includes('Tab with ID "missing" not found'));
+        assert.ok(res.content[0].text.includes('listDocumentTabs'));
+        assert.equal(ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length, before);
+        ctx.mocks.docs.service.documents.get._resetImpl();
+      });
     });
 
     describe('createParagraphBullets', () => {


### PR DESCRIPTION
## What

`applyParagraphStyle` with `textToFind` + `tabId` previously issued **two** full, unmasked `documents.get({ includeTabsContent: true })` reads of the same document — one inside `findTextRange` (range match) and another inside `getParagraphRange` (enclosing-paragraph lookup).

This collapses them into **one** GET: `findTextRange`/`getParagraphRange` now accept an optional pre-resolved body-content array, and the `applyParagraphStyle` `textToFind` branch resolves the tab body once via `getTabBodyContent` and passes it to both.

## Why

Deferred item from the PR #126 review triage. It was held back from #126 because the only clean fix touches two shared helpers across several call sites — regression risk disproportionate to a bounded perf gain inside a focused bug-fix. It belongs in its own PR with its own test pass (this one).

## Scope / safety

- The new parameter is a **backward-compatible trailing optional**, so the other `findTextRange`/`getParagraphRange` call sites (`applyTextStyle`, `createParagraphBullets`, `applyParagraphStyle` + `indexWithinParagraph`) are untouched.
- The **non-tab path is byte-for-byte unchanged** — still two cheap narrow-field GETs. The #126 default-path tests ("uses narrow-field GETs and leaks no tabId by default") still pass and still assert the narrow field mask / no `includeTabsContent`.
- An unknown `tabId` now **fails fast in the handler** (no `batchUpdate`) with the same friendly `listDocumentTabs` error — covered by a new test.

## Tests

- New: tab-scoped `applyParagraphStyle` + `textToFind` issues exactly **one** `documents.get` (the core guarantee).
- New: unknown `tabId` on that path returns the standard not-found error and issues no `batchUpdate`.
- Full suite **319 passing**; typecheck + lint clean.

Related: #114, #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)