### PR TITLE
feat(calendar): support event attachments (read + write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- **calendar:** surface event `attachments` in `getCalendarEvent`/`getCalendarEvents` responses, and accept an `attachments` array (max 25) in `createCalendarEvent`/`updateCalendarEvent` (sets the `supportsAttachments` API flag). `updateCalendarEvent` now also preserves an event's existing attachments instead of silently dropping them when `attachments` is not supplied ([#110](https://github.com/piotr-agier/google-drive-mcp/issues/110))
 - **auth:** support Workspace domain-wide delegation via `GOOGLE_DRIVE_MCP_SUBJECT`; `GOOGLE_DRIVE_MCP_SCOPES` is now honored in service-account mode ([#107](https://github.com/piotr-agier/google-drive-mcp/pull/107))
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -994,7 +994,7 @@ When binding to `127.0.0.1` (default), DNS rebinding protection is automatically
   - `summary`, `description`, `location`: Updated fields (optional)
   - `start`, `end`: Updated times (optional)
   - `attendees`: Updated attendee emails, replaces existing (optional)
-  - `attachments`: Array of `{ fileUrl, title?, mimeType? }`, replaces existing (optional, max 25); omit to keep current attachments
+  - `attachments`: Array of `{ fileUrl, title?, mimeType? }`, replaces existing (optional, max 25); omit to keep current attachments, or pass `[]` to remove all
   - `sendUpdates`: `all`, `externalOnly`, or `none` (optional, default: none)
 
 - **deleteCalendarEvent** - Delete a calendar event

--- a/README.md
+++ b/README.md
@@ -972,6 +972,7 @@ When binding to `127.0.0.1` (default), DNS rebinding protection is automatically
 - **getCalendarEvent** - Get a single calendar event by ID
   - `eventId`: Event ID
   - `calendarId`: Calendar ID (optional, default: primary)
+  - Response includes the event's file `attachments` (title and URL) when present
 
 - **createCalendarEvent** - Create a new calendar event with Google Meet support
   - `summary`: Event title
@@ -985,6 +986,7 @@ When binding to `127.0.0.1` (default), DNS rebinding protection is automatically
   - `conferenceType`: `hangoutsMeet` to add Google Meet link (optional)
   - `recurrence`: Array of RRULE strings for recurring events (optional)
   - `visibility`: `default`, `public`, `private`, or `confidential` (optional)
+  - `attachments`: Array of `{ fileUrl, title?, mimeType? }` (optional, max 25; for Drive files use the file's share URL as `fileUrl`)
 
 - **updateCalendarEvent** - Update an existing calendar event
   - `eventId`: Event ID
@@ -992,6 +994,7 @@ When binding to `127.0.0.1` (default), DNS rebinding protection is automatically
   - `summary`, `description`, `location`: Updated fields (optional)
   - `start`, `end`: Updated times (optional)
   - `attendees`: Updated attendee emails, replaces existing (optional)
+  - `attachments`: Array of `{ fileUrl, title?, mimeType? }`, replaces existing (optional, max 25); omit to keep current attachments
   - `sendUpdates`: `all`, `externalOnly`, or `none` (optional, default: none)
 
 - **deleteCalendarEvent** - Delete a calendar event

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -126,8 +126,8 @@ function formatEventForDisplay(event: CalendarEventInfo): string {
   }
   if (event.attachments && event.attachments.length > 0) {
     const items = event.attachments.map(a => {
-      const label = a.title || a.fileUrl || '(untitled)';
-      return a.fileUrl ? `${label} (${a.fileUrl})` : label;
+      if (a.title && a.fileUrl) return `${a.title} (${a.fileUrl})`;
+      return a.title || a.fileUrl || '(untitled)';
     });
     lines.push(`Attachments: ${items.join(', ')}`);
   }
@@ -303,6 +303,7 @@ export const toolDefinitions: ToolDefinition[] = [
         visibility: { type: "string", enum: ["default", "public", "private", "confidential"], description: "Event visibility" },
         attachments: {
           type: "array",
+          maxItems: 25,
           description: "File attachments (max 25). For Drive files use the file's share URL as fileUrl.",
           items: {
             type: "object",
@@ -348,6 +349,7 @@ export const toolDefinitions: ToolDefinition[] = [
         attendees: { type: "array", items: { type: "string" }, description: "Updated attendee emails (replaces existing)" },
         attachments: {
           type: "array",
+          maxItems: 25,
           description: "File attachments (max 25). Replaces existing attachments; omit to keep them. For Drive files use the file's share URL as fileUrl.",
           items: {
             type: "object",

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -173,7 +173,7 @@ const AttachmentInputSchema = z
   )
   .max(25, "A calendar event can have at most 25 attachments")
   .optional()
-  .describe("File attachments for the event (max 25). Replaces existing attachments on update.");
+  .describe("File attachments for the event (max 25). On update this replaces existing attachments; pass an empty array to remove all of them, or omit to keep them.");
 
 const CreateCalendarEventSchema = z.object({
   summary: z.string().min(1, "Event title is required"),
@@ -350,7 +350,7 @@ export const toolDefinitions: ToolDefinition[] = [
         attachments: {
           type: "array",
           maxItems: 25,
-          description: "File attachments (max 25). Replaces existing attachments; omit to keep them. For Drive files use the file's share URL as fileUrl.",
+          description: "File attachments (max 25). Replaces existing attachments; pass an empty array to remove all, or omit to keep them. For Drive files use the file's share URL as fileUrl.",
           items: {
             type: "object",
             properties: {

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -21,6 +21,7 @@ interface CalendarEventInfo {
   attendees?: { email: string; displayName?: string; responseStatus?: string }[];
   organizer?: { email?: string; displayName?: string };
   recurrence?: string[];
+  attachments?: { fileUrl?: string; title?: string; mimeType?: string; fileId?: string; iconLink?: string }[];
   created?: string;
   updated?: string;
 }
@@ -87,6 +88,16 @@ function formatCalendarEvent(event: any): CalendarEventInfo {
     result.recurrence = event.recurrence;
   }
 
+  if (event.attachments) {
+    result.attachments = event.attachments.map((a: any) => ({
+      fileUrl: a.fileUrl,
+      title: a.title,
+      mimeType: a.mimeType,
+      fileId: a.fileId,
+      iconLink: a.iconLink,
+    }));
+  }
+
   return result;
 }
 
@@ -112,6 +123,13 @@ function formatEventForDisplay(event: CalendarEventInfo): string {
   }
   if (event.attendees && event.attendees.length > 0) {
     lines.push(`Attendees: ${event.attendees.map(a => a.email).join(', ')}`);
+  }
+  if (event.attachments && event.attachments.length > 0) {
+    const items = event.attachments.map(a => {
+      const label = a.title || a.fileUrl || '(untitled)';
+      return a.fileUrl ? `${label} (${a.fileUrl})` : label;
+    });
+    lines.push(`Attachments: ${items.join(', ')}`);
   }
   if (event.htmlLink) lines.push(`Link: ${event.htmlLink}`);
   lines.push(`Event ID: ${event.id}`);
@@ -142,6 +160,21 @@ const GetCalendarEventSchema = z.object({
   calendarId: z.string().optional().default("primary").describe("Calendar ID (default: primary)")
 });
 
+// Google Calendar allows at most 25 attachments per event. `fileUrl` is the
+// only required input; `fileId`/`mimeType` are output-only and derived by the
+// API (Drive files: use the Drive file's share URL as `fileUrl`).
+const AttachmentInputSchema = z
+  .array(
+    z.object({
+      fileUrl: z.string().min(1, "Attachment fileUrl is required").describe("URL of the file to attach; for Drive files use the file's share URL"),
+      title: z.string().optional().describe("Attachment title"),
+      mimeType: z.string().optional().describe("MIME type (optional; ignored for Drive files, which the API resolves)"),
+    }),
+  )
+  .max(25, "A calendar event can have at most 25 attachments")
+  .optional()
+  .describe("File attachments for the event (max 25). Replaces existing attachments on update.");
+
 const CreateCalendarEventSchema = z.object({
   summary: z.string().min(1, "Event title is required"),
   calendarId: z.string().optional().default("primary").describe("Calendar ID (default: primary)"),
@@ -161,7 +194,8 @@ const CreateCalendarEventSchema = z.object({
   sendUpdates: z.enum(["all", "externalOnly", "none"]).optional().default("none").describe("Send notifications to attendees (default: none)"),
   conferenceType: z.enum(["hangoutsMeet"]).optional().describe("Add Google Meet link"),
   recurrence: z.array(z.string()).optional().describe("RRULE strings for recurring events"),
-  visibility: z.enum(["default", "public", "private", "confidential"]).optional().describe("Event visibility")
+  visibility: z.enum(["default", "public", "private", "confidential"]).optional().describe("Event visibility"),
+  attachments: AttachmentInputSchema
 });
 
 const UpdateCalendarEventSchema = z.object({
@@ -181,6 +215,7 @@ const UpdateCalendarEventSchema = z.object({
     timeZone: z.string().optional()
   }).optional().describe("New end time"),
   attendees: z.array(z.string()).optional().describe("Updated attendee emails (replaces existing)"),
+  attachments: AttachmentInputSchema,
   sendUpdates: z.enum(["all", "externalOnly", "none"]).optional().default("none").describe("Send notifications about the update (default: none)")
 });
 
@@ -265,7 +300,20 @@ export const toolDefinitions: ToolDefinition[] = [
         sendUpdates: { type: "string", enum: ["all", "externalOnly", "none"], description: "Send notifications (default: none)" },
         conferenceType: { type: "string", enum: ["hangoutsMeet"], description: "Add Google Meet link" },
         recurrence: { type: "array", items: { type: "string" }, description: "RRULE strings for recurring events" },
-        visibility: { type: "string", enum: ["default", "public", "private", "confidential"], description: "Event visibility" }
+        visibility: { type: "string", enum: ["default", "public", "private", "confidential"], description: "Event visibility" },
+        attachments: {
+          type: "array",
+          description: "File attachments (max 25). For Drive files use the file's share URL as fileUrl.",
+          items: {
+            type: "object",
+            properties: {
+              fileUrl: { type: "string", description: "URL of the file to attach (required)" },
+              title: { type: "string", description: "Attachment title" },
+              mimeType: { type: "string", description: "MIME type (optional; ignored for Drive files)" }
+            },
+            required: ["fileUrl"]
+          }
+        }
       },
       required: ["summary", "start", "end"]
     }
@@ -298,6 +346,19 @@ export const toolDefinitions: ToolDefinition[] = [
           }
         },
         attendees: { type: "array", items: { type: "string" }, description: "Updated attendee emails (replaces existing)" },
+        attachments: {
+          type: "array",
+          description: "File attachments (max 25). Replaces existing attachments; omit to keep them. For Drive files use the file's share URL as fileUrl.",
+          items: {
+            type: "object",
+            properties: {
+              fileUrl: { type: "string", description: "URL of the file to attach (required)" },
+              title: { type: "string", description: "Attachment title" },
+              mimeType: { type: "string", description: "MIME type (optional; ignored for Drive files)" }
+            },
+            required: ["fileUrl"]
+          }
+        },
         sendUpdates: { type: "string", enum: ["all", "externalOnly", "none"], description: "Send notifications (default: none)" }
       },
       required: ["eventId"]
@@ -433,6 +494,10 @@ export async function handleTool(
         eventResource.recurrence = parsed.recurrence;
       }
 
+      if (parsed.attachments && parsed.attachments.length > 0) {
+        eventResource.attachments = parsed.attachments;
+      }
+
       let conferenceDataVersion = 0;
       if (parsed.conferenceType === 'hangoutsMeet') {
         eventResource.conferenceData = {
@@ -447,7 +512,9 @@ export async function handleTool(
       const insertParams: any = {
         calendarId: parsed.calendarId || 'primary',
         requestBody: eventResource,
-        sendUpdates: parsed.sendUpdates
+        sendUpdates: parsed.sendUpdates,
+        // Required by the Calendar API to persist `attachments`; harmless otherwise.
+        supportsAttachments: true
       };
 
       if (conferenceDataVersion > 0) {
@@ -483,7 +550,10 @@ export async function handleTool(
         calendarId: parsed.calendarId || 'primary',
         eventId: parsed.eventId,
         requestBody: eventResource,
-        sendUpdates: parsed.sendUpdates
+        sendUpdates: parsed.sendUpdates,
+        // Required so forwarded/overridden `attachments` are persisted rather
+        // than wiped; without it the API ignores attachment changes.
+        supportsAttachments: true
       });
 
       const updated = formatCalendarEvent(response.data);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,7 @@ export interface CalendarEventOverrides {
   start?: any;
   end?: any;
   attendees?: string[];
+  attachments?: { fileUrl: string; title?: string; mimeType?: string }[];
   [key: string]: any;
 }
 
@@ -24,6 +25,10 @@ export interface CalendarEventOverrides {
  * - User overrides win when explicitly provided (even if empty string / empty array)
  * - Existing values are preserved when the override is `undefined`
  * - Attendees are mapped from `string[]` → `{email}[]`
+ * - Attachments are preserved as-is when not overridden; passing them through
+ *   (with the read-only fileId/iconLink the API returned) is required so an
+ *   update doesn't wipe an event's existing attachments. Caller must set
+ *   `supportsAttachments: true` on the update request for this to take effect.
  * - Only mutable fields are included; read-only fields (id, kind, etag, htmlLink,
  *   iCalUID, creator, organizer, sequence, …) are never forwarded
  */
@@ -37,6 +42,9 @@ export function buildCalendarEventUpdate(existing: any, overrides: CalendarEvent
     attendees:   overrides.attendees !== undefined
       ? overrides.attendees.map((email: string) => ({ email }))
       : existing.attendees,
+    attachments: overrides.attachments !== undefined
+      ? overrides.attachments
+      : existing.attachments,
     recurrence:  existing.recurrence,
     visibility:  existing.visibility,
     reminders:   existing.reminders,

--- a/test/helpers/mock-google-apis.ts
+++ b/test/helpers/mock-google-apis.ts
@@ -200,6 +200,14 @@ export function createCalendarMock() {
           start: { dateTime: '2025-01-01T10:00:00Z' },
           end: { dateTime: '2025-01-01T11:00:00Z' },
           status: 'confirmed',
+          attachments: [
+            {
+              fileUrl: 'https://drive.google.com/file/d/file-1/view',
+              title: 'Agenda.pdf',
+              mimeType: 'application/pdf',
+              fileId: 'file-1',
+            },
+          ],
         },
       ],
     }),

--- a/test/helpers/mock-google-apis.ts
+++ b/test/helpers/mock-google-apis.ts
@@ -209,6 +209,15 @@ export function createCalendarMock() {
       start: { dateTime: '2025-01-01T10:00:00Z' },
       end: { dateTime: '2025-01-01T11:00:00Z' },
       status: 'confirmed',
+      attachments: [
+        {
+          fileUrl: 'https://drive.google.com/file/d/file-1/view',
+          title: 'Agenda.pdf',
+          mimeType: 'application/pdf',
+          fileId: 'file-1',
+          iconLink: 'https://drive.google.com/icon.png',
+        },
+      ],
     }),
     insert: stub(tracker, 'events.insert', {
       id: 'event-new',

--- a/test/integration/calendar.test.ts
+++ b/test/integration/calendar.test.ts
@@ -169,6 +169,16 @@ describe('Calendar tools', () => {
         { fileUrl: 'https://drive.google.com/file/d/new/view', title: 'New' },
       ]);
     });
+
+    it('removes all attachments when given an empty array', async () => {
+      const res = await callTool(ctx.client, 'updateCalendarEvent', {
+        eventId: 'event-1', attachments: [],
+      });
+      assert.equal(res.isError, false);
+      const call = ctx.mocks.calendar.tracker.getCalls('events.update').at(-1);
+      assert.equal(call!.args[0].supportsAttachments, true);
+      assert.deepEqual(call!.args[0].requestBody.attachments, []);
+    });
   });
 
   // --- deleteCalendarEvent ---

--- a/test/integration/calendar.test.ts
+++ b/test/integration/calendar.test.ts
@@ -49,6 +49,14 @@ describe('Calendar tools', () => {
       const res = await callTool(ctx.client, 'getCalendarEvent', {});
       assert.equal(res.isError, true);
     });
+
+    it('surfaces attachments in the response', async () => {
+      const res = await callTool(ctx.client, 'getCalendarEvent', { eventId: 'event-1' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Attachments:'));
+      assert.ok(res.content[0].text.includes('Agenda.pdf'));
+      assert.ok(res.content[0].text.includes('https://drive.google.com/file/d/file-1/view'));
+    });
   });
 
   // --- createCalendarEvent ---
@@ -67,6 +75,32 @@ describe('Calendar tools', () => {
       const res = await callTool(ctx.client, 'createCalendarEvent', {});
       assert.equal(res.isError, true);
     });
+
+    it('forwards attachments and supportsAttachments to events.insert', async () => {
+      const res = await callTool(ctx.client, 'createCalendarEvent', {
+        summary: 'Event with attachment',
+        start: { dateTime: '2025-06-01T10:00:00Z' },
+        end: { dateTime: '2025-06-01T11:00:00Z' },
+        attachments: [{ fileUrl: 'https://drive.google.com/file/d/abc/view', title: 'Spec' }],
+      });
+      assert.equal(res.isError, false);
+      const call = ctx.mocks.calendar.tracker.getCalls('events.insert').at(-1);
+      assert.ok(call, 'events.insert should have been called');
+      assert.equal(call!.args[0].supportsAttachments, true);
+      assert.deepEqual(call!.args[0].requestBody.attachments, [
+        { fileUrl: 'https://drive.google.com/file/d/abc/view', title: 'Spec' },
+      ]);
+    });
+
+    it('rejects an attachment without fileUrl', async () => {
+      const res = await callTool(ctx.client, 'createCalendarEvent', {
+        summary: 'Bad attachment',
+        start: { dateTime: '2025-06-01T10:00:00Z' },
+        end: { dateTime: '2025-06-01T11:00:00Z' },
+        attachments: [{ title: 'no url' }],
+      });
+      assert.equal(res.isError, true);
+    });
   });
 
   // --- updateCalendarEvent ---
@@ -82,6 +116,32 @@ describe('Calendar tools', () => {
     it('validation error', async () => {
       const res = await callTool(ctx.client, 'updateCalendarEvent', {});
       assert.equal(res.isError, true);
+    });
+
+    it('preserves existing attachments when not overridden', async () => {
+      const res = await callTool(ctx.client, 'updateCalendarEvent', {
+        eventId: 'event-1', summary: 'Renamed, attachments untouched',
+      });
+      assert.equal(res.isError, false);
+      const call = ctx.mocks.calendar.tracker.getCalls('events.update').at(-1);
+      assert.ok(call, 'events.update should have been called');
+      assert.equal(call!.args[0].supportsAttachments, true);
+      // The existing event (from events.get) carries one attachment — it must
+      // be forwarded so the update does not wipe it.
+      assert.equal(call!.args[0].requestBody.attachments.length, 1);
+      assert.equal(call!.args[0].requestBody.attachments[0].fileId, 'file-1');
+    });
+
+    it('replaces attachments when explicitly provided', async () => {
+      const res = await callTool(ctx.client, 'updateCalendarEvent', {
+        eventId: 'event-1',
+        attachments: [{ fileUrl: 'https://drive.google.com/file/d/new/view', title: 'New' }],
+      });
+      assert.equal(res.isError, false);
+      const call = ctx.mocks.calendar.tracker.getCalls('events.update').at(-1);
+      assert.deepEqual(call!.args[0].requestBody.attachments, [
+        { fileUrl: 'https://drive.google.com/file/d/new/view', title: 'New' },
+      ]);
     });
   });
 

--- a/test/integration/calendar.test.ts
+++ b/test/integration/calendar.test.ts
@@ -35,6 +35,14 @@ describe('Calendar tools', () => {
       assert.equal(res.isError, false);
       assert.ok(res.content[0].text.includes('Test Event'));
     });
+
+    it('surfaces attachments for listed events', async () => {
+      const res = await callTool(ctx.client, 'getCalendarEvents', {});
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Attachments:'));
+      assert.ok(res.content[0].text.includes('Agenda.pdf'));
+      assert.ok(res.content[0].text.includes('https://drive.google.com/file/d/file-1/view'));
+    });
   });
 
   // --- getCalendarEvent ---
@@ -56,6 +64,24 @@ describe('Calendar tools', () => {
       assert.ok(res.content[0].text.includes('Attachments:'));
       assert.ok(res.content[0].text.includes('Agenda.pdf'));
       assert.ok(res.content[0].text.includes('https://drive.google.com/file/d/file-1/view'));
+    });
+
+    it('renders a title-less attachment without duplicating the URL', async () => {
+      ctx.mocks.calendar.service.events.get._setImpl(async () => ({
+        data: {
+          id: 'event-1',
+          summary: 'No-title attachment',
+          start: { dateTime: '2025-01-01T10:00:00Z' },
+          end: { dateTime: '2025-01-01T11:00:00Z' },
+          status: 'confirmed',
+          attachments: [{ fileUrl: 'https://example.com/f' }],
+        },
+      }));
+      const res = await callTool(ctx.client, 'getCalendarEvent', { eventId: 'event-1' });
+      ctx.mocks.calendar.service.events.get._resetImpl();
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Attachments: https://example.com/f'));
+      assert.ok(!res.content[0].text.includes('https://example.com/f (https://example.com/f)'));
     });
   });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -266,3 +266,23 @@ test('buildCalendarEventUpdate preserves recurrence from existing', () => {
   const result = buildCalendarEventUpdate(EXISTING_EVENT, { summary: 'Changed' });
   assert.deepEqual(result.recurrence, ['RRULE:FREQ=WEEKLY']);
 });
+
+test('buildCalendarEventUpdate preserves existing attachments when not overridden', () => {
+  const withAttachments = {
+    ...EXISTING_EVENT,
+    attachments: [{ fileUrl: 'https://drive.google.com/f/1', title: 'A', fileId: '1' }],
+  };
+  const result = buildCalendarEventUpdate(withAttachments, { summary: 'Changed' });
+  assert.deepEqual(result.attachments, withAttachments.attachments);
+});
+
+test('buildCalendarEventUpdate replaces attachments when overridden', () => {
+  const withAttachments = {
+    ...EXISTING_EVENT,
+    attachments: [{ fileUrl: 'https://drive.google.com/f/1', title: 'A' }],
+  };
+  const result = buildCalendarEventUpdate(withAttachments, {
+    attachments: [{ fileUrl: 'https://drive.google.com/f/2', title: 'B' }],
+  });
+  assert.deepEqual(result.attachments, [{ fileUrl: 'https://drive.google.com/f/2', title: 'B' }]);
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -286,3 +286,12 @@ test('buildCalendarEventUpdate replaces attachments when overridden', () => {
   });
   assert.deepEqual(result.attachments, [{ fileUrl: 'https://drive.google.com/f/2', title: 'B' }]);
 });
+
+test('buildCalendarEventUpdate clears attachments when given an empty array', () => {
+  const withAttachments = {
+    ...EXISTING_EVENT,
+    attachments: [{ fileUrl: 'https://drive.google.com/f/1', title: 'A' }],
+  };
+  const result = buildCalendarEventUpdate(withAttachments, { attachments: [] });
+  assert.deepEqual(result.attachments, []);
+});


### PR DESCRIPTION
Closes #110.

## Summary

Adds Google Calendar event **attachment** support, both reading and writing.

### Read (the issue ask)
- `getCalendarEvent` and `getCalendarEvents` now surface event `attachments` (title + URL) in their response. No new scopes — the Calendar API already returns the field.

### Write (extra, agreed in discussion)
- `createCalendarEvent` / `updateCalendarEvent` accept an `attachments` array: `fileUrl` (required), `title`/`mimeType` (optional), **max 25** (Calendar API limit).
- The `supportsAttachments` API flag is set on insert/update so attachments are actually persisted (the API ignores them otherwise).
- For Drive files, pass the file's share URL as `fileUrl`; non-Drive URLs are also accepted. `fileId`/`mimeType` are output-only and derived by the API.

### Bug fix (found along the way)
`buildCalendarEventUpdate` never carried `attachments` through, so **every** `updateCalendarEvent` call silently wiped an event's existing attachments. It now preserves them when `attachments` is omitted and replaces them when supplied.

## API basis
Verified against the [Calendar API events reference](https://developers.google.com/workspace/calendar/api/v3/reference/events): 25-attachment cap, `fileUrl` required + writable, `fileId`/`mimeType` output-only, `supportsAttachments` required to persist attachment changes.

## Tests
- 5 integration tests (read surfaces attachments; create forwards `attachments` + `supportsAttachments`; missing-`fileUrl` rejected; update preserves existing; update replaces when provided)
- 2 unit tests for the `buildCalendarEventUpdate` preserve/replace behavior
- Full suite green on a clean `master` base: **97/97 unit, 324/324 integration**, typecheck clean, tool count unchanged (107)

🤖 Generated with [Claude Code](https://claude.com/claude-code)