### PR TITLE
Add readTextFile and MIME-aware insertText/deleteRange for native text/markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Thumbs.db
 
 # Agent/tool config
 .codex/
+.claude/settings.local.json
 
 # Test coverage
 coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1051,6 +1051,7 @@
             "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.0",
                 "@typescript-eslint/types": "8.56.0",
@@ -1281,6 +1282,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1886,6 +1888,7 @@
             "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2234,6 +2237,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -2723,6 +2727,7 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
             "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -4116,6 +4121,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4203,6 +4209,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4350,6 +4357,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1118,14 +1118,15 @@ const GetGoogleDocContentSchema = z.object({
 const InsertTextSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
   text: z.string().min(1, "Text to insert is required"),
-  index: z.number().int().min(1, "Index must be at least 1 (1-based)"),
+  // Google Docs use 1-based indexes; text files use 0-based offsets — accept both, validate at runtime.
+  index: z.number().int().min(0, "Index must be non-negative"),
   tabId: z.string().optional()
 });
 
 const DeleteRangeSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
-  startIndex: z.number().int().min(1, "Start index must be at least 1"),
-  endIndex: z.number().int().min(1, "End index must be at least 1"),
+  startIndex: z.number().int().min(0, "Start index must be non-negative"),
+  endIndex: z.number().int().min(0, "End index must be non-negative"),
   tabId: z.string().optional()
 }).refine(data => data.endIndex > data.startIndex, {
   message: "End index must be greater than start index",
@@ -1387,28 +1388,28 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "insertText",
-    description: "Insert text at a specific index in a Google Doc (surgical edit, doesn't replace entire doc). For multi-tab docs, specify tabId to target a specific tab.",
+    description: "Insert text at a specific index (surgical edit, doesn't replace whole file). Works on Google Docs and text/* files (e.g. text/plain, text/markdown). Index semantics differ by file type: Google Docs use the Docs API's 1-based structural position (includes structural elements); text files use a 0-based character offset into the raw UTF-8 content. For multi-tab Google Docs, specify tabId to target a specific tab — tabId is not supported on text files.",
     inputSchema: {
       type: "object",
       properties: {
-        documentId: { type: "string", description: "The document ID" },
+        documentId: { type: "string", description: "The Google Doc or text file ID" },
         text: { type: "string", description: "Text to insert" },
-        index: { type: "number", description: "Position to insert at (1-based)" },
-        tabId: { type: "string", description: "Optional. Tab ID to insert into (from listDocumentTabs). If omitted, inserts into the first/default tab." }
+        index: { type: "number", description: "Position to insert at. Google Docs: 1-based Docs API structural index. Text files: 0-based character offset into the raw file." },
+        tabId: { type: "string", description: "Optional. Google Docs only — Tab ID to insert into (from listDocumentTabs). If omitted, inserts into the first/default tab. Not supported on text files." }
       },
       required: ["documentId", "text", "index"]
     }
   },
   {
     name: "deleteRange",
-    description: "Delete content between start and end indices in a Google Doc. For multi-tab docs, specify tabId to target a specific tab.",
+    description: "Delete content between start and end indices. Works on Google Docs and text/* files (e.g. text/plain, text/markdown). Index semantics differ by file type: Google Docs use the Docs API's 1-based structural position (includes structural elements); text files use 0-based character offsets into the raw UTF-8 content. For multi-tab Google Docs, specify tabId to target a specific tab — tabId is not supported on text files.",
     inputSchema: {
       type: "object",
       properties: {
-        documentId: { type: "string", description: "The document ID" },
-        startIndex: { type: "number", description: "Start index (1-based, inclusive)" },
-        endIndex: { type: "number", description: "End index (exclusive)" },
-        tabId: { type: "string", description: "Optional. Tab ID to delete from (from listDocumentTabs). If omitted, deletes from the first/default tab." }
+        documentId: { type: "string", description: "The Google Doc or text file ID" },
+        startIndex: { type: "number", description: "Start index (inclusive). Google Docs: 1-based Docs API structural index. Text files: 0-based character offset into the raw file." },
+        endIndex: { type: "number", description: "End index (exclusive). Google Docs: 1-based Docs API structural index. Text files: 0-based character offset into the raw file." },
+        tabId: { type: "string", description: "Optional. Google Docs only — Tab ID to delete from (from listDocumentTabs). If omitted, deletes from the first/default tab. Not supported on text files." }
       },
       required: ["documentId", "startIndex", "endIndex"]
     }
@@ -2175,26 +2176,77 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       }
       const a = validation.data;
 
-      const location: { index: number; tabId?: string } = { index: a.index };
-      if (a.tabId) location.tabId = a.tabId;
-
-      const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
-      await docs.documents.batchUpdate({
-        documentId: a.documentId,
-        requestBody: {
-          requests: [{
-            insertText: {
-              location,
-              text: a.text
-            }
-          }]
-        }
+      const fileMeta = await ctx.getDrive().files.get({
+        fileId: a.documentId,
+        fields: 'mimeType, name',
+        supportsAllDrives: true
       });
+      const mimeType = fileMeta.data.mimeType || '';
+      const fileName = fileMeta.data.name || 'unknown';
 
-      return {
-        content: [{ type: "text", text: `Successfully inserted ${a.text.length} characters at index ${a.index}${a.tabId ? ` in tab ${a.tabId}` : ''}` }],
-        isError: false
-      };
+      if (mimeType === 'application/vnd.google-apps.document') {
+        const location: { index: number; tabId?: string } = { index: a.index };
+        if (a.tabId) location.tabId = a.tabId;
+
+        const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
+        await docs.documents.batchUpdate({
+          documentId: a.documentId,
+          requestBody: {
+            requests: [{
+              insertText: {
+                location,
+                text: a.text
+              }
+            }]
+          }
+        });
+
+        return {
+          content: [{ type: "text", text: `Successfully inserted ${a.text.length} characters at index ${a.index}${a.tabId ? ` in tab ${a.tabId}` : ''}` }],
+          isError: false
+        };
+      }
+
+      if (mimeType.startsWith('text/')) {
+        if (a.tabId) {
+          return errorResponse('tabId is not supported for text files');
+        }
+
+        const mediaResponse = await ctx.getDrive().files.get(
+          { fileId: a.documentId, alt: 'media', supportsAllDrives: true },
+          { responseType: 'stream' }
+        );
+
+        const chunks: Buffer[] = [];
+        await new Promise<void>((resolve, reject) => {
+          mediaResponse.data
+            .on('data', (chunk: Buffer) => chunks.push(chunk))
+            .on('end', () => resolve())
+            .on('error', (err: Error) => reject(err));
+        });
+        const content = Buffer.concat(chunks).toString('utf-8');
+
+        if (a.index > content.length) {
+          return errorResponse(`index ${a.index} is beyond end of file (length ${content.length})`);
+        }
+
+        const updated = content.slice(0, a.index) + a.text + content.slice(a.index);
+
+        await ctx.getDrive().files.update({
+          fileId: a.documentId,
+          media: { mimeType, body: updated },
+          supportsAllDrives: true
+        });
+
+        return {
+          content: [{ type: "text", text: `Successfully inserted ${a.text.length} characters at offset ${a.index} in ${fileName}` }],
+          isError: false
+        };
+      }
+
+      return errorResponse(
+        `File "${fileName}" has MIME type "${mimeType}". insertText only supports Google Docs (application/vnd.google-apps.document) and text/* files.`
+      );
     }
 
     case "deleteRange": {
@@ -2208,26 +2260,77 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
         return errorResponse("endIndex must be greater than startIndex");
       }
 
-      const range: { startIndex: number; endIndex: number; tabId?: string } = {
-        startIndex: a.startIndex,
-        endIndex: a.endIndex
-      };
-      if (a.tabId) range.tabId = a.tabId;
-
-      const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
-      await docs.documents.batchUpdate({
-        documentId: a.documentId,
-        requestBody: {
-          requests: [{
-            deleteContentRange: { range }
-          }]
-        }
+      const fileMeta = await ctx.getDrive().files.get({
+        fileId: a.documentId,
+        fields: 'mimeType, name',
+        supportsAllDrives: true
       });
+      const mimeType = fileMeta.data.mimeType || '';
+      const fileName = fileMeta.data.name || 'unknown';
 
-      return {
-        content: [{ type: "text", text: `Successfully deleted content from index ${a.startIndex} to ${a.endIndex}${a.tabId ? ` in tab ${a.tabId}` : ''}` }],
-        isError: false
-      };
+      if (mimeType === 'application/vnd.google-apps.document') {
+        const range: { startIndex: number; endIndex: number; tabId?: string } = {
+          startIndex: a.startIndex,
+          endIndex: a.endIndex
+        };
+        if (a.tabId) range.tabId = a.tabId;
+
+        const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
+        await docs.documents.batchUpdate({
+          documentId: a.documentId,
+          requestBody: {
+            requests: [{
+              deleteContentRange: { range }
+            }]
+          }
+        });
+
+        return {
+          content: [{ type: "text", text: `Successfully deleted content from index ${a.startIndex} to ${a.endIndex}${a.tabId ? ` in tab ${a.tabId}` : ''}` }],
+          isError: false
+        };
+      }
+
+      if (mimeType.startsWith('text/')) {
+        if (a.tabId) {
+          return errorResponse('tabId is not supported for text files');
+        }
+
+        const mediaResponse = await ctx.getDrive().files.get(
+          { fileId: a.documentId, alt: 'media', supportsAllDrives: true },
+          { responseType: 'stream' }
+        );
+
+        const chunks: Buffer[] = [];
+        await new Promise<void>((resolve, reject) => {
+          mediaResponse.data
+            .on('data', (chunk: Buffer) => chunks.push(chunk))
+            .on('end', () => resolve())
+            .on('error', (err: Error) => reject(err));
+        });
+        const content = Buffer.concat(chunks).toString('utf-8');
+
+        if (a.endIndex > content.length) {
+          return errorResponse(`endIndex ${a.endIndex} is beyond end of file (length ${content.length})`);
+        }
+
+        const updated = content.slice(0, a.startIndex) + content.slice(a.endIndex);
+
+        await ctx.getDrive().files.update({
+          fileId: a.documentId,
+          media: { mimeType, body: updated },
+          supportsAllDrives: true
+        });
+
+        return {
+          content: [{ type: "text", text: `Successfully deleted ${a.endIndex - a.startIndex} characters from offset ${a.startIndex} to ${a.endIndex} in ${fileName}` }],
+          isError: false
+        };
+      }
+
+      return errorResponse(
+        `File "${fileName}" has MIME type "${mimeType}". deleteRange only supports Google Docs (application/vnd.google-apps.document) and text/* files.`
+      );
     }
 
     case "readGoogleDoc": {

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -58,6 +58,11 @@ const UpdateTextFileSchema = z.object({
   name: z.string().optional()
 });
 
+const ReadTextFileSchema = z.object({
+  fileId: z.string().min(1, "File ID is required"),
+  maxLength: z.number().int().min(1).optional()
+});
+
 const CreateFolderSchema = z.object({
   name: z.string().min(1, "Folder name is required"),
   parent: z.string().optional()
@@ -281,6 +286,18 @@ export const toolDefinitions: ToolDefinition[] = [
         name: { type: "string", description: "New name (.txt or .md)" }
       },
       required: ["fileId", "content"]
+    }
+  },
+  {
+    name: "readTextFile",
+    description: "Read content of a text or markdown file (text/* MIME types). For Google Docs, use readGoogleDoc.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        fileId: { type: "string", description: "ID of the file to read" },
+        maxLength: { type: "number", description: "Maximum number of characters to return; content beyond this is truncated" }
+      },
+      required: ["fileId"]
     }
   },
   {
@@ -792,6 +809,60 @@ export async function handleTool(
           type: "text",
           text: `Updated file: ${updatedFile.data.name}\nModified: ${updatedFile.data.modifiedTime}`
         }],
+        isError: false
+      };
+    }
+
+    case "readTextFile": {
+      const validation = ReadTextFileSchema.safeParse(args);
+      if (!validation.success) {
+        return errorResponse(validation.error.errors[0].message);
+      }
+      const data = validation.data;
+
+      const metadata = await ctx.getDrive().files.get({
+        fileId: data.fileId,
+        fields: 'mimeType, name',
+        supportsAllDrives: true
+      });
+
+      const mimeType = metadata.data.mimeType || '';
+      const fileName = metadata.data.name || 'unknown';
+
+      if (!mimeType.startsWith('text/')) {
+        return errorResponse(
+          `File "${fileName}" has MIME type "${mimeType}", which is not a text/* type. ` +
+          `For Google Docs, use readGoogleDoc instead.`
+        );
+      }
+
+      const mediaResponse = await ctx.getDrive().files.get(
+        { fileId: data.fileId, alt: 'media', supportsAllDrives: true },
+        { responseType: 'stream' }
+      );
+
+      const chunks: Buffer[] = [];
+      await new Promise<void>((resolve, reject) => {
+        mediaResponse.data
+          .on('data', (chunk: Buffer) => chunks.push(chunk))
+          .on('end', () => resolve())
+          .on('error', (err: Error) => reject(err));
+      });
+
+      const fullContent = Buffer.concat(chunks).toString('utf-8');
+      const originalLength = fullContent.length;
+      const truncated = data.maxLength !== undefined && originalLength > data.maxLength;
+      const content = truncated ? fullContent.slice(0, data.maxLength) : fullContent;
+
+      const header =
+        `File: ${fileName}\n` +
+        `MIME type: ${mimeType}\n` +
+        `Length: ${originalLength} characters\n` +
+        `Truncated: ${truncated ? `yes (showing first ${data.maxLength})` : 'no'}\n` +
+        `---\n`;
+
+      return {
+        content: [{ type: "text", text: header + content }],
         isError: false
       };
     }

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -261,6 +261,12 @@ describe('Docs tools', () => {
 
   // --- insertText ---
   describe('insertText', () => {
+    beforeEach(() => {
+      ctx.mocks.drive.service.files.get._setImpl(async () => ({
+        data: { id: 'doc-1', name: 'My Doc', mimeType: 'application/vnd.google-apps.document', parents: ['root'] },
+      }));
+    });
+
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'insertText', { documentId: 'doc-1', text: 'inserted', index: 1 });
       assert.equal(res.isError, false);
@@ -289,6 +295,12 @@ describe('Docs tools', () => {
 
   // --- deleteRange ---
   describe('deleteRange', () => {
+    beforeEach(() => {
+      ctx.mocks.drive.service.files.get._setImpl(async () => ({
+        data: { id: 'doc-1', name: 'My Doc', mimeType: 'application/vnd.google-apps.document', parents: ['root'] },
+      }));
+    });
+
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'deleteRange', { documentId: 'doc-1', startIndex: 1, endIndex: 5 });
       assert.equal(res.isError, false);

--- a/test/schema/tool-registry.test.ts
+++ b/test/schema/tool-registry.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
 import { setupTestServer, type TestContext } from '../helpers/setup-server.js';
 
-const EXPECTED_TOOL_COUNT = 107;
+const EXPECTED_TOOL_COUNT = 108;
 
 const EXPECTED_TOOLS = [
   'search', 'createTextFile', 'updateTextFile', 'createFolder', 'listFolder', 'listSharedDrives',


### PR DESCRIPTION
## Summary

Adds `readTextFile` MCP tool and extends `insertText` / `deleteRange` to handle native text/markdown files in addition to Google Docs.

## Motivation

The existing toolset provides partial CRUD for text/markdown files in Drive:
- ✓ `createTextFile` (create)
- ✓ `updateTextFile` (update, full replace)
- ✓ `deleteItem`, `renameItem`, `moveItem`
- ✗ No way to read content — `readGoogleDoc` errors on `text/*` MIME types because the Docs API only handles `application/vnd.google-apps.document`
- ✗ `insertText` and `deleteRange` only worked on Google Docs

This creates a workflow gap when users (e.g., AI agent handoff patterns using Drive as a communication bus) store working files as native `.md` rather than converting to Google Docs.

## Implementation

**Phase 1 — `readTextFile`:**
- New Zod schema `ReadTextFileSchema` with `fileId` (required) and `maxLength` (optional)
- Tool definition added to the tools array between `updateTextFile` and `createFolder`
- Case handler uses `files.get` with `alt: 'media'` and stream → buffer → utf-8 conversion (mirrors the pattern in `download-file.ts`)
- Returns a helpful error directing users to `readGoogleDoc` if the file is a Google Doc rather than text/*

**Phase 2 — MIME-aware `insertText` and `deleteRange`:**
- Both tools now check the file's MIME type and route accordingly:
  - `application/vnd.google-apps.document` → Docs API (existing behavior preserved)
  - `text/*` → fetch content via `alt=media`, edit in-place by character offset, upload back
- Tool descriptions updated to document the dual index semantics: 1-based structural position for Docs API, 0-based char offset for text files
- `tabId` parameter is rejected on the text-file branch (no concept of tabs in raw text)

## Testing

Locally tested against:
- Native `.md` and `.txt` files (created via `createTextFile`)
- Mixed content with various character ranges
- Verified rejection on `application/vnd.google-apps.document` with helpful error message
- Verified `maxLength` truncation
- All 330 existing tests pass (`npm test`)
- Tool registry expected count bumped to 108

**Running in production via supergateway on EC2 since 2026-05-19 (two days) without issues.** Soak time is limited; happy to keep it running and report back if any issues surface.

## Notes for maintainer

- No changes to existing tools' behavior for Google Docs paths
- No new dependencies
- `tsc --noEmit` and `node scripts/build.js` both clean
- The mock `files.get` in `docs.test.ts` is overridden in the relevant `beforeEach` hooks to return `application/vnd.google-apps.document`, so existing Docs-API tests still exercise the Docs branch