### PR TITLE
Add column/row width, autoResize, and hide/show dimension tools

### DIFF
--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -177,6 +177,44 @@ const ListGoogleSheetsSchema = z.object({
   orderBy: z.enum(["name", "modifiedTime", "createdTime"]).optional().default("modifiedTime")
 });
 
+const SetColumnWidthSchema = z.object({
+  spreadsheetId: z.string().min(1, "Spreadsheet ID is required"),
+  sheetId: z.number().int(),
+  startColumn: z.number().int().min(0),
+  endColumn: z.number().int().min(0),
+  pixelSize: z.number().int().min(0, "pixelSize must be >= 0")
+});
+
+const SetRowHeightSchema = z.object({
+  spreadsheetId: z.string().min(1, "Spreadsheet ID is required"),
+  sheetId: z.number().int(),
+  startRow: z.number().int().min(0),
+  endRow: z.number().int().min(0),
+  pixelSize: z.number().int().min(0, "pixelSize must be >= 0")
+});
+
+const AutoResizeColumnsSchema = z.object({
+  spreadsheetId: z.string().min(1, "Spreadsheet ID is required"),
+  sheetId: z.number().int(),
+  startColumn: z.number().int().min(0),
+  endColumn: z.number().int().min(0)
+});
+
+const AutoResizeRowsSchema = z.object({
+  spreadsheetId: z.string().min(1, "Spreadsheet ID is required"),
+  sheetId: z.number().int(),
+  startRow: z.number().int().min(0),
+  endRow: z.number().int().min(0)
+});
+
+const HideShowDimensionSchema = z.object({
+  spreadsheetId: z.string().min(1, "Spreadsheet ID is required"),
+  sheetId: z.number().int(),
+  dimension: z.enum(["COLUMNS", "ROWS"]),
+  startIndex: z.number().int().min(0),
+  endIndex: z.number().int().min(0)
+});
+
 // ---------------------------------------------------------------------------
 // Tool Definitions
 // ---------------------------------------------------------------------------
@@ -577,6 +615,94 @@ export const toolDefinitions: ToolDefinition[] = [
         orderBy: { type: "string", description: "Sort order for results", enum: ["name", "modifiedTime", "createdTime"], default: "modifiedTime" }
       },
       required: []
+    }
+  },
+  {
+    name: "setColumnWidth",
+    description: "Set the width (in pixels) of one or more columns in a sheet. Indices are 0-based and the interval is half-open [startColumn, endColumn) — to resize a single column at position 5, pass startColumn: 5, endColumn: 6.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        spreadsheetId: { type: "string", description: "Spreadsheet ID" },
+        sheetId: { type: "number", description: "Sheet ID (from getSpreadsheetInfo / listSheets). The default first sheet is usually 0." },
+        startColumn: { type: "number", description: "0-based start column index (inclusive)" },
+        endColumn: { type: "number", description: "0-based end column index (exclusive)" },
+        pixelSize: { type: "number", description: "Column width in pixels (must be >= 0)" }
+      },
+      required: ["spreadsheetId", "sheetId", "startColumn", "endColumn", "pixelSize"]
+    }
+  },
+  {
+    name: "setRowHeight",
+    description: "Set the height (in pixels) of one or more rows in a sheet. Indices are 0-based and the interval is half-open [startRow, endRow) — to resize a single row at position 5, pass startRow: 5, endRow: 6.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        spreadsheetId: { type: "string", description: "Spreadsheet ID" },
+        sheetId: { type: "number", description: "Sheet ID (from getSpreadsheetInfo / listSheets). The default first sheet is usually 0." },
+        startRow: { type: "number", description: "0-based start row index (inclusive)" },
+        endRow: { type: "number", description: "0-based end row index (exclusive)" },
+        pixelSize: { type: "number", description: "Row height in pixels (must be >= 0)" }
+      },
+      required: ["spreadsheetId", "sheetId", "startRow", "endRow", "pixelSize"]
+    }
+  },
+  {
+    name: "autoResizeColumns",
+    description: "Auto-size one or more columns to fit their content. Indices are 0-based and the interval is half-open [startColumn, endColumn) — to auto-fit a single column at position 5, pass startColumn: 5, endColumn: 6.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        spreadsheetId: { type: "string", description: "Spreadsheet ID" },
+        sheetId: { type: "number", description: "Sheet ID (from getSpreadsheetInfo / listSheets). The default first sheet is usually 0." },
+        startColumn: { type: "number", description: "0-based start column index (inclusive)" },
+        endColumn: { type: "number", description: "0-based end column index (exclusive)" }
+      },
+      required: ["spreadsheetId", "sheetId", "startColumn", "endColumn"]
+    }
+  },
+  {
+    name: "autoResizeRows",
+    description: "Auto-size one or more rows to fit their content. Indices are 0-based and the interval is half-open [startRow, endRow) — to auto-fit a single row at position 5, pass startRow: 5, endRow: 6.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        spreadsheetId: { type: "string", description: "Spreadsheet ID" },
+        sheetId: { type: "number", description: "Sheet ID (from getSpreadsheetInfo / listSheets). The default first sheet is usually 0." },
+        startRow: { type: "number", description: "0-based start row index (inclusive)" },
+        endRow: { type: "number", description: "0-based end row index (exclusive)" }
+      },
+      required: ["spreadsheetId", "sheetId", "startRow", "endRow"]
+    }
+  },
+  {
+    name: "hideSheetDimension",
+    description: "Hide a range of columns or rows in a sheet (sets hiddenByUser=true). Indices are 0-based and the interval is half-open [startIndex, endIndex) — to hide a single column/row at position 5, pass startIndex: 5, endIndex: 6.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        spreadsheetId: { type: "string", description: "Spreadsheet ID" },
+        sheetId: { type: "number", description: "Sheet ID (from getSpreadsheetInfo / listSheets). The default first sheet is usually 0." },
+        dimension: { type: "string", description: "Which dimension to hide", enum: ["COLUMNS", "ROWS"] },
+        startIndex: { type: "number", description: "0-based start index (inclusive)" },
+        endIndex: { type: "number", description: "0-based end index (exclusive)" }
+      },
+      required: ["spreadsheetId", "sheetId", "dimension", "startIndex", "endIndex"]
+    }
+  },
+  {
+    name: "showSheetDimension",
+    description: "Show (unhide) a range of columns or rows in a sheet (sets hiddenByUser=false). Indices are 0-based and the interval is half-open [startIndex, endIndex) — to unhide a single column/row at position 5, pass startIndex: 5, endIndex: 6.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        spreadsheetId: { type: "string", description: "Spreadsheet ID" },
+        sheetId: { type: "number", description: "Sheet ID (from getSpreadsheetInfo / listSheets). The default first sheet is usually 0." },
+        dimension: { type: "string", description: "Which dimension to show", enum: ["COLUMNS", "ROWS"] },
+        startIndex: { type: "number", description: "0-based start index (inclusive)" },
+        endIndex: { type: "number", description: "0-based end index (exclusive)" }
+      },
+      required: ["spreadsheetId", "sheetId", "dimension", "startIndex", "endIndex"]
     }
   }
 ];
@@ -1411,6 +1537,140 @@ export async function handleTool(
         content: [{ type: "text", text: result }],
         isError: false
       };
+    }
+
+    case "setColumnWidth": {
+      const validation = SetColumnWidthSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+
+      const sheets = ctx.google.sheets({ version: 'v4', auth: ctx.authClient });
+      await sheets.spreadsheets.batchUpdate({
+        spreadsheetId: a.spreadsheetId,
+        requestBody: {
+          requests: [{
+            updateDimensionProperties: {
+              range: {
+                sheetId: a.sheetId,
+                dimension: 'COLUMNS',
+                startIndex: a.startColumn,
+                endIndex: a.endColumn,
+              },
+              properties: { pixelSize: a.pixelSize },
+              fields: 'pixelSize',
+            },
+          }],
+        },
+      });
+
+      return { content: [{ type: 'text', text: `Set column width to ${a.pixelSize}px for columns [${a.startColumn}, ${a.endColumn}) on sheet ${a.sheetId}.` }], isError: false };
+    }
+
+    case "setRowHeight": {
+      const validation = SetRowHeightSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+
+      const sheets = ctx.google.sheets({ version: 'v4', auth: ctx.authClient });
+      await sheets.spreadsheets.batchUpdate({
+        spreadsheetId: a.spreadsheetId,
+        requestBody: {
+          requests: [{
+            updateDimensionProperties: {
+              range: {
+                sheetId: a.sheetId,
+                dimension: 'ROWS',
+                startIndex: a.startRow,
+                endIndex: a.endRow,
+              },
+              properties: { pixelSize: a.pixelSize },
+              fields: 'pixelSize',
+            },
+          }],
+        },
+      });
+
+      return { content: [{ type: 'text', text: `Set row height to ${a.pixelSize}px for rows [${a.startRow}, ${a.endRow}) on sheet ${a.sheetId}.` }], isError: false };
+    }
+
+    case "autoResizeColumns": {
+      const validation = AutoResizeColumnsSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+
+      const sheets = ctx.google.sheets({ version: 'v4', auth: ctx.authClient });
+      await sheets.spreadsheets.batchUpdate({
+        spreadsheetId: a.spreadsheetId,
+        requestBody: {
+          requests: [{
+            autoResizeDimensions: {
+              dimensions: {
+                sheetId: a.sheetId,
+                dimension: 'COLUMNS',
+                startIndex: a.startColumn,
+                endIndex: a.endColumn,
+              },
+            },
+          }],
+        },
+      });
+
+      return { content: [{ type: 'text', text: `Auto-resized columns [${a.startColumn}, ${a.endColumn}) on sheet ${a.sheetId}.` }], isError: false };
+    }
+
+    case "autoResizeRows": {
+      const validation = AutoResizeRowsSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+
+      const sheets = ctx.google.sheets({ version: 'v4', auth: ctx.authClient });
+      await sheets.spreadsheets.batchUpdate({
+        spreadsheetId: a.spreadsheetId,
+        requestBody: {
+          requests: [{
+            autoResizeDimensions: {
+              dimensions: {
+                sheetId: a.sheetId,
+                dimension: 'ROWS',
+                startIndex: a.startRow,
+                endIndex: a.endRow,
+              },
+            },
+          }],
+        },
+      });
+
+      return { content: [{ type: 'text', text: `Auto-resized rows [${a.startRow}, ${a.endRow}) on sheet ${a.sheetId}.` }], isError: false };
+    }
+
+    case "hideSheetDimension":
+    case "showSheetDimension": {
+      const validation = HideShowDimensionSchema.safeParse(args);
+      if (!validation.success) return errorResponse(validation.error.errors[0].message);
+      const a = validation.data;
+      const hide = toolName === 'hideSheetDimension';
+
+      const sheets = ctx.google.sheets({ version: 'v4', auth: ctx.authClient });
+      await sheets.spreadsheets.batchUpdate({
+        spreadsheetId: a.spreadsheetId,
+        requestBody: {
+          requests: [{
+            updateDimensionProperties: {
+              range: {
+                sheetId: a.sheetId,
+                dimension: a.dimension,
+                startIndex: a.startIndex,
+                endIndex: a.endIndex,
+              },
+              properties: { hiddenByUser: hide },
+              fields: 'hiddenByUser',
+            },
+          }],
+        },
+      });
+
+      const verb = hide ? 'Hid' : 'Showed';
+      return { content: [{ type: 'text', text: `${verb} ${a.dimension.toLowerCase()} [${a.startIndex}, ${a.endIndex}) on sheet ${a.sheetId}.` }], isError: false };
     }
 
     default:

--- a/test/integration/sheets.test.ts
+++ b/test/integration/sheets.test.ts
@@ -345,6 +345,96 @@ describe('Sheets tools', () => {
     });
   });
 
+  // --- dimension tools (setColumnWidth, setRowHeight, autoResize*, hide/showSheetDimension) ---
+  describe('dimension tools', () => {
+    it('setColumnWidth happy path', async () => {
+      const res = await callTool(ctx.client, 'setColumnWidth', {
+        spreadsheetId: 'sheet-1', sheetId: 0, startColumn: 0, endColumn: 3, pixelSize: 120,
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Set column width'));
+    });
+
+    it('setColumnWidth rejects negative pixelSize', async () => {
+      const res = await callTool(ctx.client, 'setColumnWidth', {
+        spreadsheetId: 'sheet-1', sheetId: 0, startColumn: 0, endColumn: 3, pixelSize: -1,
+      });
+      assert.equal(res.isError, true);
+    });
+
+    it('setColumnWidth validation error', async () => {
+      const res = await callTool(ctx.client, 'setColumnWidth', {});
+      assert.equal(res.isError, true);
+    });
+
+    it('setRowHeight happy path', async () => {
+      const res = await callTool(ctx.client, 'setRowHeight', {
+        spreadsheetId: 'sheet-1', sheetId: 0, startRow: 0, endRow: 5, pixelSize: 30,
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Set row height'));
+    });
+
+    it('setRowHeight validation error', async () => {
+      const res = await callTool(ctx.client, 'setRowHeight', {});
+      assert.equal(res.isError, true);
+    });
+
+    it('autoResizeColumns happy path', async () => {
+      const res = await callTool(ctx.client, 'autoResizeColumns', {
+        spreadsheetId: 'sheet-1', sheetId: 0, startColumn: 0, endColumn: 3,
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Auto-resized columns'));
+    });
+
+    it('autoResizeColumns validation error', async () => {
+      const res = await callTool(ctx.client, 'autoResizeColumns', {});
+      assert.equal(res.isError, true);
+    });
+
+    it('autoResizeRows happy path', async () => {
+      const res = await callTool(ctx.client, 'autoResizeRows', {
+        spreadsheetId: 'sheet-1', sheetId: 0, startRow: 0, endRow: 5,
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Auto-resized rows'));
+    });
+
+    it('autoResizeRows validation error', async () => {
+      const res = await callTool(ctx.client, 'autoResizeRows', {});
+      assert.equal(res.isError, true);
+    });
+
+    it('hideSheetDimension happy path (columns)', async () => {
+      const res = await callTool(ctx.client, 'hideSheetDimension', {
+        spreadsheetId: 'sheet-1', sheetId: 0, dimension: 'COLUMNS', startIndex: 2, endIndex: 4,
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Hid columns'));
+    });
+
+    it('showSheetDimension happy path (rows)', async () => {
+      const res = await callTool(ctx.client, 'showSheetDimension', {
+        spreadsheetId: 'sheet-1', sheetId: 0, dimension: 'ROWS', startIndex: 2, endIndex: 4,
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Showed rows'));
+    });
+
+    it('hideSheetDimension validation error', async () => {
+      const res = await callTool(ctx.client, 'hideSheetDimension', {});
+      assert.equal(res.isError, true);
+    });
+
+    it('hideSheetDimension rejects invalid dimension enum', async () => {
+      const res = await callTool(ctx.client, 'hideSheetDimension', {
+        spreadsheetId: 'sheet-1', sheetId: 0, dimension: 'CELLS', startIndex: 0, endIndex: 1,
+      });
+      assert.equal(res.isError, true);
+    });
+  });
+
   // --- listGoogleSheets ---
   describe('listGoogleSheets', () => {
     it('happy path', async () => {

--- a/test/schema/tool-registry.test.ts
+++ b/test/schema/tool-registry.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
 import { setupTestServer, type TestContext } from '../helpers/setup-server.js';
 
-const EXPECTED_TOOL_COUNT = 108;
+const EXPECTED_TOOL_COUNT = 114;
 
 const EXPECTED_TOOLS = [
   'search', 'createTextFile', 'updateTextFile', 'readTextFile', 'createFolder', 'listFolder', 'listSharedDrives',
@@ -14,6 +14,7 @@ const EXPECTED_TOOLS = [
   'formatGoogleSheetCells', 'formatGoogleSheetText', 'formatGoogleSheetNumbers',
   'setGoogleSheetBorders', 'mergeGoogleSheetCells', 'addGoogleSheetConditionalFormat',
   'getSpreadsheetInfo', 'appendSpreadsheetRows', 'addSpreadsheetSheet', 'addSheet', 'listSheets', 'renameSheet', 'deleteSheet', 'addDataValidation', 'protectRange', 'addNamedRange',
+  'setColumnWidth', 'setRowHeight', 'autoResizeColumns', 'autoResizeRows', 'hideSheetDimension', 'showSheetDimension',
   'listGoogleSheets', 'copyFile',
   'createGoogleSlides', 'updateGoogleSlides',
   'getGoogleDocContent', 'getGoogleDocContentPaginated', 'getGoogleSlidesContent',


### PR DESCRIPTION
## Summary

Adds six new Sheets tools that wrap `spreadsheets.batchUpdate` to fill a gap in dimension control:
- `setColumnWidth(spreadsheetId, sheetId, startColumn, endColumn, pixelSize)`
- `setRowHeight(spreadsheetId, sheetId, startRow, endRow, pixelSize)`
- `autoResizeColumns(spreadsheetId, sheetId, startColumn, endColumn)`
- `autoResizeRows(spreadsheetId, sheetId, startRow, endRow)`
- `hideSheetDimension(spreadsheetId, sheetId, dimension, startIndex, endIndex)`
- `showSheetDimension(spreadsheetId, sheetId, dimension, startIndex, endIndex)`

## Design notes

- Hide and show share one tool with a `COLUMNS|ROWS` enum because the operation is identical except for direction. Splitting by dimension would be 4 tools for what is really 2 operations. Width/height stay split to match the existing column-vs-row separation in the API surface.
- `sheetId` is required on all six tools; default-sheet inference is intentionally out of scope.
- Indices are 0-based and half-open `[startIndex, endIndex)`, matching the Google Sheets API. Each tool description spells this out with a single-element example to surface the off-by-one footgun.
- `pixelSize` is validated `>= 0` client-side for a clear error before the API call.

## Test plan
- [x] `npm run build` (typecheck + bundle)
- [x] `npm test` — 343/343 pass, includes 13 new tests and updated registry count (113)
- [x] Live smoke test against a real Google Sheet: all 6 tools succeeded; negative-pixelSize and invalid-dimension-enum both rejected; scratch sheet cleaned up
