### PR TITLE
feat(uploadFile): in-place version updates via fileId + contentBase64 input

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,9 +523,11 @@ When binding to `127.0.0.1` (default), DNS rebinding protection is automatically
 - **authListScopes** - Show configured/requested scopes, granted scopes, missing scopes, and presets
 - **authTestFileAccess** - Test Drive access (optionally against a specific `fileId`)
 
-- **uploadFile** - Upload a local file (any type: image, audio, video, PDF, etc.) to Google Drive
-  - `localPath`: Absolute path to the local file
-  - `name`: File name in Drive (optional, defaults to local filename)
+- **uploadFile** - Upload a file (any type: image, audio, video, PDF, etc.) to Google Drive, either from a local path or from base64-encoded content. Can also upload the content as a new version of an existing file (in-place update)
+  - `localPath`: Absolute path to the local file (provide either `localPath` or `contentBase64`)
+  - `contentBase64`: Base64-encoded file content — alternative to `localPath`, useful for remote/HTTP deployments where the client has no access to the server's filesystem (optional)
+  - `fileId`: ID of an existing file to update in place — the uploaded content becomes a new version of that file, keeping its ID, links, and revision history (optional; omit to create a new file. Not combinable with `parentFolderId` or `convertToGoogleFormat`)
+  - `name`: File name in Drive (optional, defaults to local filename; required when creating a new file from `contentBase64`)
   - `parentFolderId`: Parent folder ID or path (optional, e.g., '/Work/Projects')
   - `mimeType`: MIME type (optional, auto-detected from extension)
   - `convertToGoogleFormat`: Convert uploaded file to native Google Workspace format (optional, default: false). When enabled, Office files are automatically converted:

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { drive_v3 } from 'googleapis';
 import { existsSync, statSync, createReadStream } from 'fs';
+import { Readable } from 'stream';
 import { mkdtemp, readFile, writeFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { basename, extname, join } from 'path';
@@ -111,12 +112,17 @@ const UnlockFileSchema = z.object({
 });
 
 const UploadFileSchema = z.object({
-  localPath: z.string().min(1, "Local file path is required"),
+  localPath: z.string().min(1).optional(),
+  contentBase64: z.string().min(1).optional(),
+  fileId: z.string().min(1).optional(),
   name: z.string().optional(),
   parentFolderId: z.string().optional(),
   mimeType: z.string().optional(),
   convertToGoogleFormat: z.boolean().optional()
-});
+}).refine(
+  (data) => !!data.localPath !== !!data.contentBase64,
+  { message: "Provide exactly one of localPath or contentBase64" }
+);
 
 const DownloadFileSchema = z.object({
   fileId: z.string().min(1, "File ID is required"),
@@ -368,17 +374,19 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "uploadFile",
-    description: "Upload a local file (any type: image, audio, video, PDF, etc.) to Google Drive",
+    description: "Upload a file (any type: image, audio, video, PDF, etc.) to Google Drive, either from a local path on the server or from base64-encoded content. When fileId is provided, uploads the content as a new version of that existing file (in-place update) instead of creating a new file.",
     inputSchema: {
       type: "object",
       properties: {
-        localPath: { type: "string", description: "Absolute path to the local file to upload" },
-        name: { type: "string", description: "File name in Drive (defaults to local filename)" },
-        parentFolderId: { type: "string", description: "Parent folder ID or path (e.g., '/Work/Projects'). Creates folders if needed. Defaults to root." },
+        localPath: { type: "string", description: "Absolute path to the local file to upload (on the machine running this server). Provide either localPath or contentBase64." },
+        contentBase64: { type: "string", description: "Base64-encoded file content. Alternative to localPath for clients without access to the server's filesystem. Provide either localPath or contentBase64." },
+        fileId: { type: "string", description: "ID of an existing Drive file to update in place: the uploaded content becomes a new version of this file (same ID, revision history preserved). Omit to create a new file." },
+        name: { type: "string", description: "File name in Drive (defaults to local filename; required when creating a new file from contentBase64)" },
+        parentFolderId: { type: "string", description: "Parent folder ID or path (e.g., '/Work/Projects'). Creates folders if needed. Defaults to root. Not allowed with fileId (use moveItem to move a file)." },
         mimeType: { type: "string", description: "MIME type (auto-detected from extension if omitted)" },
-        convertToGoogleFormat: { type: "boolean", description: "Convert uploaded file to Google Workspace format (e.g., .docx to Google Doc, .xlsx to Google Sheet, .pptx to Google Slides). Defaults to false." }
+        convertToGoogleFormat: { type: "boolean", description: "Convert uploaded file to Google Workspace format (e.g., .docx to Google Doc, .xlsx to Google Sheet, .pptx to Google Slides). Defaults to false. Not allowed with fileId." }
       },
-      required: ["localPath"]
+      required: []
     }
   },
   {
@@ -1184,16 +1192,52 @@ export async function handleTool(
       }
       const data = validation.data;
 
-      // Validate local file exists
-      if (!existsSync(data.localPath)) {
-        return errorResponse(`File not found: ${data.localPath}`);
+      if (data.fileId && data.convertToGoogleFormat) {
+        return errorResponse('convertToGoogleFormat cannot be combined with fileId (in-place update).');
+      }
+      if (data.fileId && data.parentFolderId) {
+        return errorResponse('parentFolderId cannot be combined with fileId (in-place update). Use moveItem to move a file.');
       }
 
-      const stats = statSync(data.localPath);
-      const fileName = data.name || data.localPath.split(/[\\/]/).pop() || 'upload';
+      let contentBuffer: Buffer | undefined;
+      let contentSize: number;
+      if (data.localPath) {
+        // Validate local file exists
+        if (!existsSync(data.localPath)) {
+          return errorResponse(`File not found: ${data.localPath}`);
+        }
+        contentSize = statSync(data.localPath).size;
+      } else {
+        contentBuffer = Buffer.from(data.contentBase64!, 'base64');
+        contentSize = contentBuffer.length;
+      }
+      const mediaBody = () => contentBuffer ? Readable.from(contentBuffer) : createReadStream(data.localPath!);
+
+      const fileName = data.name || data.localPath?.split(/[\\/]/).pop() || '';
+      if (!fileName && !data.fileId) {
+        return errorResponse('name is required when creating a new file from contentBase64.');
+      }
       const ext = fileName.split('.').pop()?.toLowerCase() || '';
-      const detectedMime = data.mimeType || BINARY_MIME_TYPES[ext] || 'application/octet-stream';
-      const parentId = await ctx.resolveFolderId(data.parentFolderId);
+      let detectedMime = data.mimeType || BINARY_MIME_TYPES[ext] || '';
+      if (!detectedMime && data.fileId) {
+        // In-place update with no MIME hint: reuse the existing file's MIME type
+        const existing = await ctx.getDrive().files.get({
+          fileId: data.fileId,
+          fields: 'mimeType',
+          supportsAllDrives: true
+        });
+        const existingMime = existing.data.mimeType || '';
+        if (existingMime.startsWith('application/vnd.google-apps')) {
+          return errorResponse(
+            `File ${data.fileId} is a Google Workspace file (${existingMime}). ` +
+            `Specify mimeType (e.g. the Office format of the uploaded content) so Drive can convert it.`
+          );
+        }
+        detectedMime = existingMime;
+      }
+      if (!detectedMime) {
+        detectedMime = 'application/octet-stream';
+      }
 
       // Google Workspace conversion mapping
       const GOOGLE_FORMAT_MAP: Record<string, string> = {
@@ -1216,34 +1260,55 @@ export async function handleTool(
 
       const uploadName = targetMimeType ? fileName.replace(/\.[^.]+$/, '') : fileName;
 
-      ctx.log('Uploading file', { localPath: data.localPath, name: uploadName, mimeType: detectedMime, convertToGoogle: !!targetMimeType, size: stats.size });
+      ctx.log('Uploading file', { localPath: data.localPath, fileId: data.fileId, name: uploadName, mimeType: detectedMime, convertToGoogle: !!targetMimeType, size: contentSize });
 
-      const requestBody: any = {
-        name: uploadName,
-        parents: [parentId]
-      };
-      if (targetMimeType) {
-        requestBody.mimeType = targetMimeType;
+      let file;
+      if (data.fileId) {
+        // In-place update: upload content as a new version of the existing file
+        const requestBody: any = {};
+        if (data.name) {
+          requestBody.name = data.name;
+        }
+        file = await ctx.getDrive().files.update({
+          fileId: data.fileId,
+          requestBody,
+          media: {
+            mimeType: detectedMime,
+            body: mediaBody()
+          },
+          fields: 'id, name, size, mimeType, webViewLink',
+          supportsAllDrives: true
+        });
+      } else {
+        const parentId = await ctx.resolveFolderId(data.parentFolderId);
+        const requestBody: any = {
+          name: uploadName,
+          parents: [parentId]
+        };
+        if (targetMimeType) {
+          requestBody.mimeType = targetMimeType;
+        }
+        file = await ctx.getDrive().files.create({
+          requestBody,
+          media: {
+            mimeType: detectedMime,
+            body: mediaBody()
+          },
+          fields: 'id, name, size, mimeType, webViewLink',
+          supportsAllDrives: true
+        });
       }
 
-      const file = await ctx.getDrive().files.create({
-        requestBody,
-        media: {
-          mimeType: detectedMime,
-          body: createReadStream(data.localPath)
-        },
-        fields: 'id, name, size, mimeType, webViewLink',
-        supportsAllDrives: true
-      });
-
-      ctx.log('File uploaded successfully', { fileId: file.data?.id });
+      ctx.log('File uploaded successfully', { fileId: file.data?.id, updated: !!data.fileId });
       return {
         content: [{
           type: "text",
           text: [
-            `Uploaded: ${file.data?.name || fileName}`,
+            data.fileId
+              ? `Updated (new version): ${file.data?.name || fileName}`
+              : `Uploaded: ${file.data?.name || fileName}`,
             `ID: ${file.data?.id || 'unknown'}`,
-            `Size: ${file.data?.size || stats.size} bytes`,
+            `Size: ${file.data?.size || contentSize} bytes`,
             `Type: ${file.data?.mimeType || detectedMime}`,
             file.data?.webViewLink ? `Link: ${file.data.webViewLink}` : ''
           ].filter(Boolean).join('\n')

--- a/test/integration/upload-download.test.ts
+++ b/test/integration/upload-download.test.ts
@@ -23,6 +23,88 @@ describe('Upload & Download tools', () => {
       assert.equal(res.isError, true);
       assert.ok(res.content[0].text.includes('not found'));
     });
+
+    it('validation error when both localPath and contentBase64 are provided', async () => {
+      const res = await callTool(ctx.client, 'uploadFile', {
+        localPath: '/tmp/a.png',
+        contentBase64: 'aGVsbG8=',
+      });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text.includes('exactly one'));
+    });
+
+    it('creates a new file from contentBase64', async () => {
+      const res = await callTool(ctx.client, 'uploadFile', {
+        contentBase64: Buffer.from('hello world').toString('base64'),
+        name: 'hello.png',
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Uploaded:'));
+      const creates = ctx.mocks.drive.tracker.getCalls('files.create');
+      assert.equal(creates.length, 1);
+      assert.equal(creates[0].args[0].requestBody.name, 'hello.png');
+      assert.equal(creates[0].args[0].media.mimeType, 'image/png');
+      assert.equal(ctx.mocks.drive.tracker.getCalls('files.update').length, 0);
+    });
+
+    it('error when creating from contentBase64 without a name', async () => {
+      const res = await callTool(ctx.client, 'uploadFile', {
+        contentBase64: 'aGVsbG8=',
+      });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text.includes('name is required'));
+    });
+
+    it('uploads a new version of an existing file when fileId is provided', async () => {
+      const res = await callTool(ctx.client, 'uploadFile', {
+        fileId: 'file-1',
+        contentBase64: Buffer.from('new content').toString('base64'),
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Updated (new version)'));
+      const updates = ctx.mocks.drive.tracker.getCalls('files.update');
+      assert.equal(updates.length, 1);
+      assert.equal(updates[0].args[0].fileId, 'file-1');
+      // No MIME hint given: reuses the existing file's MIME type (from files.get)
+      assert.equal(updates[0].args[0].media.mimeType, 'text/plain');
+      assert.equal(ctx.mocks.drive.tracker.getCalls('files.create').length, 0);
+    });
+
+    it('rejects fileId combined with convertToGoogleFormat', async () => {
+      const res = await callTool(ctx.client, 'uploadFile', {
+        fileId: 'file-1',
+        contentBase64: 'aGVsbG8=',
+        convertToGoogleFormat: true,
+      });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text.includes('convertToGoogleFormat'));
+    });
+
+    it('rejects fileId combined with parentFolderId', async () => {
+      const res = await callTool(ctx.client, 'uploadFile', {
+        fileId: 'file-1',
+        contentBase64: 'aGVsbG8=',
+        parentFolderId: '/Work',
+      });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text.includes('parentFolderId'));
+    });
+
+    it('rejects in-place update of a Google Workspace file without explicit mimeType', async () => {
+      ctx.mocks.drive.service.files.get._setImpl(async () => ({
+        data: { mimeType: 'application/vnd.google-apps.document' },
+      }));
+      try {
+        const res = await callTool(ctx.client, 'uploadFile', {
+          fileId: 'doc-1',
+          contentBase64: 'aGVsbG8=',
+        });
+        assert.equal(res.isError, true);
+        assert.ok(res.content[0].text.includes('Google Workspace file'));
+      } finally {
+        ctx.mocks.drive.service.files.get._resetImpl();
+      }
+    });
   });
 
   // --- downloadFile ---


### PR DESCRIPTION
## Problem

`uploadFile` always calls `files.create`, so there is no way to upload content as a **new version of an existing file** — every upload creates a new file with a new ID, breaking shared links and losing revision history. The only workarounds are the Drive web UI ("Manage versions") or other integrations.

Additionally, `localPath` reads from the filesystem of the machine running the server. With the Streamable HTTP transport (remote/hosted deployments, e.g. Cloud Run), MCP clients have no access to that filesystem, which makes `uploadFile` effectively unusable remotely.

## Changes

Two new optional parameters on `uploadFile`, both backward-compatible:

- **`fileId`** — when provided, the content is uploaded via `files.update` as a new version of that file: same ID, links keep working, revision history is preserved (the same technique `restoreRevision` already uses internally).
  - `parentFolderId` is rejected in this mode (moving is `moveItem`'s job) and so is `convertToGoogleFormat`.
  - If no MIME hint is available (no `mimeType`, no recognizable extension), the existing file's MIME type is reused. Updating a native Google Workspace file requires an explicit `mimeType` (e.g. the Office format of the uploaded content) so Drive can convert it, instead of silently corrupting the doc.
- **`contentBase64`** — alternative to `localPath` for clients that can't reach the server's filesystem. Exactly one of `localPath` / `contentBase64` must be provided (zod `refine`); `name` is required when creating a new file from `contentBase64`.

## Testing

- 7 new integration tests in `test/integration/upload-download.test.ts` covering create-from-base64, in-place update (asserts `files.update` with the right `fileId`/MIME), and all rejection paths.
- Full suite passes: 337/337, eslint clean.
- Verified end-to-end against a live Cloud Run deployment: create → update by `fileId` → same ID, content replaced, 2 revisions visible via `getRevisions`.

README tool reference updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)