### PR TITLE
fix(uploadFile): validate contentBase64 + cover in-place update paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ When binding to `127.0.0.1` (default), DNS rebinding protection is automatically
 
 - **uploadFile** - Upload a file (any type: image, audio, video, PDF, etc.) to Google Drive, either from a local path or from base64-encoded content. Can also upload the content as a new version of an existing file (in-place update)
   - `localPath`: Absolute path to the local file (provide either `localPath` or `contentBase64`)
-  - `contentBase64`: Base64-encoded file content — alternative to `localPath`, useful for remote/HTTP deployments where the client has no access to the server's filesystem (optional)
+  - `contentBase64`: Base64-encoded file content — alternative to `localPath`, useful for remote/HTTP deployments where the client has no access to the server's filesystem (optional). Must be valid (standard) base64; invalid input is rejected
   - `fileId`: ID of an existing file to update in place — the uploaded content becomes a new version of that file, keeping its ID, links, and revision history (optional; omit to create a new file. Not combinable with `parentFolderId` or `convertToGoogleFormat`)
   - `name`: File name in Drive (optional, defaults to local filename; required when creating a new file from `contentBase64`)
   - `parentFolderId`: Parent folder ID or path (optional, e.g., '/Work/Projects')

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1209,7 +1209,14 @@ export async function handleTool(
         }
         contentSize = statSync(data.localPath).size;
       } else {
-        contentBuffer = Buffer.from(data.contentBase64!, 'base64');
+        // Node's base64 decoder silently drops invalid characters rather than
+        // throwing, so validate the payload before decoding to avoid uploading
+        // truncated/empty content as a "success".
+        const b64 = data.contentBase64!.replace(/\s/g, '');
+        if (!b64 || b64.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(b64)) {
+          return errorResponse('contentBase64 is not valid base64-encoded content.');
+        }
+        contentBuffer = Buffer.from(b64, 'base64');
         contentSize = contentBuffer.length;
       }
       const mediaBody = () => contentBuffer ? Readable.from(contentBuffer) : createReadStream(data.localPath!);
@@ -1263,9 +1270,11 @@ export async function handleTool(
 
       ctx.log('Uploading file', { localPath: data.localPath, fileId: data.fileId, name: uploadName, mimeType: detectedMime, convertToGoogle: !!targetMimeType, size: contentSize });
 
-      let file;
+      let file: { data?: drive_v3.Schema$File };
       if (data.fileId) {
-        // In-place update: upload content as a new version of the existing file
+        // In-place update: upload content as a new version of the existing file.
+        // The stored file's mimeType is intentionally left unchanged (new-version
+        // semantics, not a type change) — only the content/revision is replaced.
         const requestBody: any = {};
         if (data.name) {
           requestBody.name = data.name;

--- a/test/helpers/mock-google-apis.ts
+++ b/test/helpers/mock-google-apis.ts
@@ -29,10 +29,28 @@ export class CallTracker {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+// The real Google API reads the upload's media.body stream. Mirror that here so a
+// createReadStream (or any Readable) passed as media.body is fully consumed and closed
+// before the call resolves — otherwise a stream over a temp fixture can open the file
+// after the test deleted it, surfacing as async-activity-after-test-end.
+async function drainMediaBody(args: any[]) {
+  for (const a of args) {
+    const body = a?.media?.body;
+    if (body && typeof body.resume === 'function' && typeof body.on === 'function') {
+      await new Promise<void>((resolve) => {
+        body.on('end', resolve);
+        body.on('error', resolve);
+        body.resume();
+      });
+    }
+  }
+}
+
 function stub(tracker: CallTracker, name: string, defaultReturn: any = {}) {
   let impl: ((...a: any[]) => any) | null = null;
   const fn = async (...args: any[]) => {
     tracker.record(name, args);
+    await drainMediaBody(args);
     if (impl) return impl(...args);
     return { data: typeof defaultReturn === 'function' ? defaultReturn() : defaultReturn };
   };

--- a/test/integration/upload-download.test.ts
+++ b/test/integration/upload-download.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it, before, after, beforeEach } from 'node:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { setupTestServer, callTool, type TestContext } from '../helpers/setup-server.js';
 
 describe('Upload & Download tools', () => {
@@ -104,6 +107,69 @@ describe('Upload & Download tools', () => {
       } finally {
         ctx.mocks.drive.service.files.get._resetImpl();
       }
+    });
+
+    it('rejects contentBase64 that is not valid base64', async () => {
+      const res = await callTool(ctx.client, 'uploadFile', {
+        contentBase64: '@@@not-valid@@@',
+        name: 'bad.png',
+      });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text.includes('valid base64'));
+      assert.equal(ctx.mocks.drive.tracker.getCalls('files.create').length, 0);
+      assert.equal(ctx.mocks.drive.tracker.getCalls('files.update').length, 0);
+    });
+
+    it('rejects whitespace-only contentBase64', async () => {
+      const res = await callTool(ctx.client, 'uploadFile', {
+        contentBase64: '   \n  ',
+        name: 'blank.png',
+      });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text.includes('valid base64'));
+      assert.equal(ctx.mocks.drive.tracker.getCalls('files.create').length, 0);
+    });
+
+    it('uploads a new version from a local file when fileId is provided', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'upl-'));
+      const localPath = join(dir, 'v2.png');
+      writeFileSync(localPath, Buffer.from('local bytes'));
+      try {
+        const res = await callTool(ctx.client, 'uploadFile', {
+          fileId: 'file-1',
+          localPath,
+        });
+        assert.equal(res.isError, false);
+        assert.ok(res.content[0].text.includes('Updated (new version)'));
+        const updates = ctx.mocks.drive.tracker.getCalls('files.update');
+        assert.equal(updates.length, 1);
+        assert.equal(updates[0].args[0].fileId, 'file-1');
+        // MIME comes from the .png extension, so the existing file's MIME is not fetched
+        assert.equal(updates[0].args[0].media.mimeType, 'image/png');
+        assert.equal(ctx.mocks.drive.tracker.getCalls('files.get').length, 0);
+        assert.equal(ctx.mocks.drive.tracker.getCalls('files.create').length, 0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('updates a Workspace file in place when an explicit Office mimeType is given', async () => {
+      const docxMime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+      const res = await callTool(ctx.client, 'uploadFile', {
+        fileId: 'doc-1',
+        contentBase64: Buffer.from('docx bytes').toString('base64'),
+        mimeType: docxMime,
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text.includes('Updated (new version)'));
+      const updates = ctx.mocks.drive.tracker.getCalls('files.update');
+      assert.equal(updates.length, 1);
+      assert.equal(updates[0].args[0].fileId, 'doc-1');
+      assert.equal(updates[0].args[0].media.mimeType, docxMime);
+      // Stored file's mimeType is left unchanged so Drive converts the upload into the
+      // existing Doc; an explicit mimeType also means the existing type is never fetched.
+      assert.equal(updates[0].args[0].requestBody.mimeType, undefined);
+      assert.equal(ctx.mocks.drive.tracker.getCalls('files.get').length, 0);
     });
   });
 


### PR DESCRIPTION
## Context

Follow-up to #138, which added `fileId` (in-place version update) and `contentBase64` inputs to `uploadFile`. This PR addresses the nits and test gaps raised in that PR's review. No behavior change on the happy paths.

## Changes

- **Validate `contentBase64` before decoding.** `Buffer.from(x, 'base64')` silently drops invalid characters rather than throwing, so a malformed/truncated/whitespace-only payload previously uploaded truncated-or-empty content and reported it as a success (`Uploaded:` / `Updated (new version)`). It's now rejected with `Error: contentBase64 is not valid base64-encoded content.` Standard base64 only (matches the README wording); base64url is intentionally out of scope.
- **Cosmetic:** typed the `file` result var (drops an implicit `any`), and added a comment documenting that in-place update intentionally leaves the stored file's `mimeType` unchanged (new-version semantics, not a type change).
- **Closed two test gaps from #138** (all its `fileId` tests used `contentBase64`, and only the Workspace *rejection* path was covered):
  - in-place update sourced from a `localPath`
  - Workspace-conversion **success** path (explicit Office `mimeType`), pinning that `files.update` is called with the Office `media.mimeType` and an unset `requestBody.mimeType`
  - plus invalid-base64 and whitespace-only rejection tests
- **Test mock:** `files.*` stubs now drain a stream `media.body` (mirrors the real API reading the upload) so a stream over a temp fixture is consumed/closed before the call resolves — avoids fd leaks and async-activity-after-test races.
- **README:** note that `contentBase64` must be valid standard base64.

## Testing

- `npm run lint` clean; `upload-download.test.ts` passes (14/14, incl. 4 new).
- Full suite: the only failures are the pre-existing flaky subprocess/timer tests in `cli-args` / `http-transport` (they fail identically on `master` without this change); all drive/docs/sheets/slides suites — which exercise the shared mock change — pass.

## ⚠️ Known limitation to verify before relying on it

The Workspace-conversion **success** test pins the *call shape* only (mock level). The actual Drive-side conversion on `files.update` — uploading an Office file as new content of a native Google Doc — was **not** verified against a live Doc in #138 either. Recommend a one-off live check before depending on that path: create a Doc → `uploadFile` with `fileId` + docx `mimeType` → confirm content is replaced, the file stays a Google Doc, and a new revision appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)