### PR TITLE
chore: prepare release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.3.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.2.0...v2.3.0) (2026-07-11)
+
 Substantial internal refactor to introduce **multi-account support**: one running server can now hold OAuth credentials for several Google accounts (e.g. personal + Workspace) and route each tool call to the right identity. The change is strictly additive at the contract level — existing single-account users upgrade with no re-consent, no config changes, and no user-visible behavior change.
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
Prepares the **2.3.0** release, finalizing the multi-account support cycle.

## Changes
- Bump version `2.2.0 → 2.3.0` in `package.json` + `package-lock.json`.
- Finalize `CHANGELOG.md`: move the `[Unreleased]` notes into a dated `[2.3.0]` section with a `v2.2.0...v2.3.0` compare link.

## Why 2.3.0 (semver minor, not 3.0.0)
The public contract is strictly additive — new tools and optional parameters, no removals or renames — despite the internal multi-account refactor and the `tokens.json` v2 migration. This matches the earlier decision to reframe 3.0.0 → 2.3.0, and the README already references "pre-2.3".

## Validation
- `npm run build` (typecheck + bundle): clean.
- `npm test`: all suites pass in isolation; the `--version` output correctly reports `2.3.0`. A handful of subprocess/timer integration tests (`cli-args`, `http-transport`, `refresh-round-trip`) flake under full-suite parallel load — pre-existing, unrelated to the version bump.

## Follow-up (not in this PR)
After merge, tag `v2.3.0` and cut the GitHub Release to trigger the npm OIDC publish workflow (which verifies the tag matches `package.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)