### PR TITLE
ci: bump checkout & setup-node to v5 (off deprecated Node 20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [22]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Bumps `actions/checkout` and `actions/setup-node` from `@v4` to `@v5` in both `ci.yml` and `publish.yml`.

## Why
The v2.3.0 publish run surfaced a GitHub deprecation annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4.

v5 of both actions natively targets a supported Node runtime, clearing the warning before the forced migration becomes a hard failure.

## Scope
- No behavior change: the `node-version` pins (22), `cache: npm`, `registry-url`, and every other step config are untouched — only the action major versions change.
- Affects CI and the npm publish workflow equally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)