### PR TITLE
fix(auth): resolve OAuth keys project-root fallback for the bundled build

### DIFF
--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,14 +1,31 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { fileURLToPath } from 'url';
 
-// Helper to get the project root directory reliably
+// Walk up from `startDir` to the nearest ancestor containing a package.json and
+// return it. This is robust to the build layout — bundled output is
+// `dist/index.js`, an unbundled build would be `dist/auth/utils.js`, and an
+// installed package lives at `node_modules/<pkg>/dist/index.js`; all resolve to
+// the package root. A previous hard-coded "up two levels" assumed the unbundled
+// `dist/auth/utils.js` path, so with the bundled `dist/index.js` it resolved to
+// the package's PARENT directory instead and the project-root fallback for
+// `gcp-oauth.keys.json` never matched. Exported for testing.
+export function findPackageRoot(startDir: string): string {
+  let dir = startDir;
+  const fsRoot = path.parse(dir).root;
+  while (true) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) return dir;
+    if (dir === fsRoot) break;
+    dir = path.dirname(dir);
+  }
+  // Fallback to the legacy behavior if no package.json is found on the path.
+  return path.resolve(startDir, '..', '..');
+}
+
+// Helper to get the project root directory reliably.
 function getProjectRoot(): string {
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  // In build output (e.g., dist/auth/utils.js), __dirname is .../dist/auth
-  // Go up TWO levels to get the project root
-  const projectRoot = path.join(__dirname, "..", "..");
-  return path.resolve(projectRoot);
+  return findPackageRoot(path.dirname(fileURLToPath(import.meta.url)));
 }
 
 // Returns the config directory for google-drive-mcp, following XDG Base Directory spec.

--- a/test/auth/keys-path-resolution.test.ts
+++ b/test/auth/keys-path-resolution.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { findPackageRoot } from '../../src/auth/utils.js';
+
+// Regression guard for the OAuth-keys project-root fallback. The build bundles
+// to `dist/index.js`, so `getProjectRoot()` used to resolve two levels up from
+// `dist/` — i.e. the package's PARENT — and the keys fallback path never
+// matched. `findPackageRoot` must resolve the package root regardless of build
+// layout. Note: the unbundled test build happens to make the old "up two"
+// correct, which is exactly why the bug shipped — hence this fixture-based test
+// that exercises the bundled layout explicitly.
+test('findPackageRoot resolves the package root for both bundled and unbundled layouts', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gdmcp-pkgroot-'));
+  try {
+    fs.writeFileSync(path.join(root, 'package.json'), '{"name":"fixture"}');
+    const distAuth = path.join(root, 'dist', 'auth');
+    fs.mkdirSync(distAuth, { recursive: true });
+
+    // Bundled: module at <root>/dist/index.js  ->  startDir = <root>/dist
+    const bundledStart = path.join(root, 'dist');
+    assert.equal(
+      findPackageRoot(bundledStart),
+      root,
+      'bundled dist/index.js must resolve to the package root, not its parent',
+    );
+    // The old hard-coded "up two levels" would have returned the parent of root.
+    assert.notEqual(
+      findPackageRoot(bundledStart),
+      path.resolve(bundledStart, '..', '..'),
+      'must not regress to the package parent (the original bug)',
+    );
+
+    // Unbundled: module at <root>/dist/auth/utils.js  ->  startDir = <root>/dist/auth
+    assert.equal(
+      findPackageRoot(distAuth),
+      root,
+      'unbundled dist/auth/utils.js must also resolve to the package root',
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/auth/store-setdefault.test.ts
+++ b/test/auth/store-setdefault.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { AccountStore } from '../../src/auth/accountStore.js';
+
+// Guards that `setDefault` is applied both to disk and to the in-memory view a
+// same-process read observes, when awaited sequentially. (The `manage_accounts
+// set_default` handler awaits this write before responding, so a request/response
+// client always observes the new default on its next call. Reads are synchronous
+// and bypass the write queue, so a caller that fires a concurrent read WITHOUT
+// awaiting the set_default response may transiently see the old value — that is a
+// client ordering concern, not a store defect. This test pins the sequential
+// contract the store must uphold.)
+test('setDefault updates both disk and in-memory getDefault when awaited', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gdmcp-setdefault-'));
+  const fp = path.join(dir, 'tokens.json');
+  const rec = (alias: string, sub: string) => ({
+    alias, email: `${alias}@x`, sub,
+    accessToken: 'x', refreshToken: 'y', scope: '', tokenType: 'Bearer',
+    expiryDate: 9999999999999, addedAt: '2026-01-01T00:00:00.000Z', pendingIdentity: false,
+  });
+  fs.writeFileSync(fp, JSON.stringify({
+    version: 2, defaultAccount: 'default',
+    accounts: { default: rec('default', '1'), work: rec('work', '2') },
+  }));
+  try {
+    const store = new AccountStore({ filePath: fp, mode: 'local-oauth' });
+    await store.reload();
+    assert.equal(store.getDefault(), 'default', 'precondition: default is the default');
+
+    await store.setDefault('work');
+    assert.equal(store.getDefault(), 'work', 'in-memory getDefault reflects the new default');
+    assert.equal(
+      JSON.parse(fs.readFileSync(fp, 'utf-8')).defaultAccount,
+      'work',
+      'the new default is persisted to disk',
+    );
+
+    await store.setDefault(null);
+    assert.equal(store.getDefault(), undefined, 'clearing the default is reflected in memory');
+    assert.equal(
+      JSON.parse(fs.readFileSync(fp, 'utf-8')).defaultAccount,
+      undefined,
+      'cleared default is persisted (field removed)',
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

`getProjectRoot()` computed the package root as **two levels up** from the
compiled module directory, with a comment assuming an unbundled
`dist/auth/utils.js` layout. The build actually bundles to a single
`dist/index.js`, so "up two" resolves to the package's **parent** directory.

Consequently the `gcp-oauth.keys.json` project-root fallback (path #3 in
`getKeysFilePaths()`) — and the legacy token path — never matched. It surfaces
as `OAuth credentials not found` when the config dir is absent even though a
keys file sits at the package/repo root (e.g. running `node dist/index.js auth`
from the repo, or after stashing `~/.config/google-drive-mcp`). For an installed
package the same off-by-one points path #3 at `node_modules/<scope>/`, so the
fallback is effectively dead in every layout.

## Fix

Replace the hard-coded walk with `findPackageRoot(startDir)`, which walks up to
the nearest ancestor containing a `package.json`. Correct for bundled
(`dist/index.js`), unbundled (`dist/auth/utils.js`), and installed-package
(`node_modules/<pkg>/dist/index.js`) layouts. Falls back to the previous
behavior only if no `package.json` is found on the path.

## Tests

- **`test/auth/keys-path-resolution.test.ts`** — fixture-based regression test
  that exercises the **bundled** layout explicitly. Note: the unbundled test
  build made the old "up two levels" coincidentally correct, which is exactly
  why this bug shipped uncaught — so the test simulates `dist/index.js` directly.
- **`test/auth/store-setdefault.test.ts`** — added while investigating a separate
  report (see below); pins `AccountStore.setDefault`'s sequential contract
  (persists to disk **and** updates the in-memory view).

All 644 tests pass; typecheck clean.

## Out of scope (documented, not fixed here)

While investigating, two things surfaced:

1. A report of "mid-session `set_default` staleness" turned out to be a **test
   artifact** (batch-piping concurrent JSON-RPC requests; reads are synchronous
   while the write is deferred through the async write queue). The `set_default`
   handler awaits its write, so a normal request/response client is unaffected —
   **not a bug.** The new store test documents the correct behavior.
2. A genuine but narrow issue remains: a running server loads `tokens.json` once
   at startup and never reloads it, so it won't see account changes made by a
   **separate** CLI process until reconnect. Left as a documented follow-up (a
   small mtime-based reload would address it); not included here to keep this PR
   focused on the keys-path fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
