### PR TITLE
docs(team): recommend MCP_TRUST_PROXY behind a proxy; warn at startup when unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ google-drive-mcp start --transport http --host 0.0.0.0 --port 3100 \
 | `MCP_TEAM_TOKEN_TTL` | — | `3600` | Access-token lifetime in seconds (60–86400) |
 | `MCP_TEAM_STORE` | — | `file` | `file` or `memory`. The file store survives restarts; the memory store forces re-consent on every restart |
 | `MCP_TEAM_STORE_PATH` | — | `<config dir>/team-store.json` | Location of the persistent store |
-| `MCP_TRUST_PROXY` | — | unset | Trusted reverse-proxy hop count (`1` behind Cloud Run/nginx). Without it, all users behind the proxy share one rate-limit bucket |
+| `MCP_TRUST_PROXY` | — | unset | **Recommended whenever the server is behind a reverse proxy** (Cloud Run/nginx/tunnel): trusted hop count (`1` for a single proxy). Without it, per-user rate limiting collapses to one shared bucket and the proxy's `X-Forwarded-For` header makes the rate limiter log an `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` error |
 | `MCP_HTTP_ALLOWED_HOSTS` | — | issuer hostname | Extra allowed `Host` header values |
 
 Team mode is mutually exclusive with service-account and external-token modes, never reads or writes `tokens.json`, and disables `manage_accounts`, the per-tool `account` parameter, and the `gdrive:///` resources capability — identity always comes from the bearer token. Google scopes follow `GOOGLE_DRIVE_MCP_SCOPES` as usual; each user's tool access is additionally gated by the scopes they actually granted at their own consent screen.
@@ -478,7 +478,7 @@ Team mode is mutually exclusive with service-account and external-token modes, n
 ### Security notes
 
 - **`team-store.json` is the deployment's most sensitive file.** It holds every member's Google refresh token (necessarily in cleartext — they must be replayed to Google) plus registered clients; MCP tokens are stored only as SHA-256 hashes. It is written with mode `0600` — protect the volume accordingly.
-- **TLS is required.** Run behind a reverse proxy that terminates https for the issuer URL; the issuer must be https (enforced at startup, localhost excepted for development).
+- **TLS is required.** Run behind a reverse proxy that terminates https for the issuer URL; the issuer must be https (enforced at startup, localhost excepted for development). When you do, set `MCP_TRUST_PROXY` to the number of proxy hops (`1` for a single proxy) so per-user rate limiting and client-IP handling stay correct — the server logs a startup warning if it is left unset with a non-localhost issuer.
 - **Every authorization shows a Google consent screen** (`prompt=consent`). This is deliberate: with one Google client serving dynamically registered MCP clients, silent re-consent would let a malicious registered client mint tokens for anyone who clicks a link.
 - **Single process assumption.** In-flight sign-ins and authorization codes live in memory, and the file store serializes writes per process — run exactly one instance (e.g. Cloud Run `--max-instances=1`). On platforms with ephemeral filesystems, mount a volume for `MCP_TEAM_STORE_PATH` or members re-consent after every redeploy.
 - **Revocation**: a user can disconnect the connector client-side, revoke the app at [Google Account Permissions](https://myaccount.google.com/permissions) (the server detects the dead grant, drops that user's tokens, and forces a fresh sign-in), or an operator can delete the user's entry from `team-store.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1487,6 +1487,23 @@ async function startHttpTransport(args: CliArgs): Promise<void> {
             ? `  Allowed domains: ${teamConfig.allowedDomains.join(', ')}\n`
             : '  Allowed domains: (any Google account)\n'),
       );
+      // Team mode is designed to sit behind an https-terminating reverse proxy.
+      // Without `trust proxy`, express-rate-limit rejects the proxy's
+      // X-Forwarded-For header (ERR_ERL_UNEXPECTED_X_FORWARDED_FOR) and per-user
+      // rate limiting degrades to one shared bucket. Warn when it's likely wrong.
+      if (teamConfig.trustProxy === undefined) {
+        const host = teamConfig.issuerUrl.hostname;
+        const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+        if (!isLocalhost) {
+          console.error(
+            'Warning: MCP_TRUST_PROXY is unset. Team mode is meant to run behind an https-terminating ' +
+              'reverse proxy; set MCP_TRUST_PROXY to the trusted hop count (1 for a single proxy such as ' +
+              "Cloud Run/nginx or a tunnel) so per-user rate limiting keys on the real client IP. Otherwise " +
+              "the proxy's X-Forwarded-For header makes express-rate-limit error " +
+              '(ERR_ERL_UNEXPECTED_X_FORWARDED_FOR) and all users share one rate-limit bucket.',
+          );
+        }
+      }
     }
 
     const { app, sessions } = createHttpApp(httpHost, teamRuntime ? { teamAuth: teamRuntime } : undefined);


### PR DESCRIPTION
## Problem

Team mode's Security notes mandate running behind an https-terminating reverse proxy, but `MCP_TRUST_PROXY` was framed as optional / "nice-to-have". Behind any proxy (Cloud Run, nginx, a tunnel), leaving it unset:

- collapses per-user rate limiting to a single shared bucket (every user keyed by the proxy's IP), and
- makes `express-rate-limit` log a scary `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` error on the proxy's `X-Forwarded-For` header.

Surfaced during the team-mode manual e2e (all 6 blockers passed).

## Change

- **README** — present `MCP_TRUST_PROXY` as **recommended whenever the server is behind a reverse proxy** (config table + Security notes), and mention the `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` error.
- **`src/index.ts`** — log a one-line startup warning in team mode when `MCP_TRUST_PROXY` is unset **and** the issuer is not localhost (so local dev stays quiet).

## Verification

- `npm run build` (typecheck + bundle) clean.
- Startup warning fires exactly in the intended cases:
  - non-localhost https issuer + no trust proxy → warning ✅
  - non-localhost + `MCP_TRUST_PROXY=1` → no warning ✅
  - localhost issuer + no trust proxy → no warning ✅
- Separately confirmed during the e2e that with `MCP_TRUST_PROXY=1` the `/token` limiter keys on the real client IP (two `X-Forwarded-For` values get separate buckets) and no `ERR_ERL` error is logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)