### PR TITLE
refactor(team): reuse isLoopbackHost in the trust-proxy startup warning

### DIFF
--- a/src/auth/team/config.ts
+++ b/src/auth/team/config.ts
@@ -34,7 +34,7 @@ export interface TeamConfig {
   advertisedScopes: string[];
 }
 
-function isLoopbackHost(hostname: string): boolean {
+export function isLoopbackHost(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1';
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import {
 import type { AccountOps, AddAccountResult, ToolContext, ToolResult } from './types.js';
 import { errorResponse } from './types.js';
 import { loadRuntimeConfig, parseBoolEnv, type RuntimeConfig } from './utils/cliArgs.js';
-import { GOOGLE_CALLBACK_PATH, loadTeamConfig } from './auth/team/config.js';
+import { GOOGLE_CALLBACK_PATH, isLoopbackHost, loadTeamConfig } from './auth/team/config.js';
 import { createTeamRuntime, type TeamRuntime } from './auth/team/runtime.js';
 import { coversScopes } from './auth/accountResolver.js';
 import { describeErrorForLog } from './auth/utils.js';
@@ -1492,9 +1492,7 @@ async function startHttpTransport(args: CliArgs): Promise<void> {
       // X-Forwarded-For header (ERR_ERL_UNEXPECTED_X_FORWARDED_FOR) and per-user
       // rate limiting degrades to one shared bucket. Warn when it's likely wrong.
       if (teamConfig.trustProxy === undefined) {
-        const host = teamConfig.issuerUrl.hostname;
-        const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
-        if (!isLocalhost) {
+        if (!isLoopbackHost(teamConfig.issuerUrl.hostname)) {
           console.error(
             'Warning: MCP_TRUST_PROXY is unset. Team mode is meant to run behind an https-terminating ' +
               'reverse proxy; set MCP_TRUST_PROXY to the trusted hop count (1 for a single proxy such as ' +


### PR DESCRIPTION
## Summary
- Exports `isLoopbackHost` from `auth/team/config` and reuses it for the `MCP_TRUST_PROXY` startup-warning check in `index.ts` instead of a duplicated inline check
- The shared helper also matches `::1` without brackets, which the inline check missed

The docs/warning change originally on this branch landed on master separately as `7e2651c`; after rebasing, this PR contains only the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)