### PR TITLE
feat(docs): surface embedded inline images and add getGoogleDocImage (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **docs:** surface embedded inline images instead of dropping or opaquely placeholdering them. `readGoogleDoc`/`readGoogleDocPaginated` now render each inline image (markdown → `![alt](contentUri "objectId=…")`; text → a single-line `[image: objectId=… contentUri=… sourceUri=… size=WxHpt]` token) instead of silently omitting it, and `getGoogleDocContent`/`getGoogleDocContentPaginated` upgrade the bare `[image]` placeholder to the same self-describing token (objectId, contentUri/sourceUri, size, alt text). A new **`getGoogleDocImage`** tool fetches an inline image's bytes by `(documentId, inlineObjectId)` — it re-fetches the doc to resolve a fresh, non-expired image URL and returns a native MCP image block (or, with `outputFormat: "base64"`, a `{ inlineObjectId, mimeType, byteLength, dataBase64 }` envelope) so downstream OCR/vision/forwarding workflows can reach the content. Keyed by the durable objectId (never a raw contentUri, which expires ~30 min). Floating/anchored images stored as `positionedObjects` remain unrendered (documented limitation) ([#132](https://github.com/piotr-agier/google-drive-mcp/issues/132))
+
 ## [2.4.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.3.0...v2.4.0) (2026-07-15)
 
 Adds opt-in **team mode**: an MCP-spec OAuth 2.1 authorization server for multi-user HTTP deployments, so a single running server can be shared by a team (e.g. through claude.ai custom connectors) with each member authenticated individually and every tool call running as the caller. Purely additive — default stdio/HTTP behavior for existing single-user deployments is unchanged.

--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ Team mode is mutually exclusive with service-account and external-token modes, n
   - `documentId`: Document ID
   - `format`: Output format — `text`, `json`, or `markdown` (optional, default: text)
   - `maxLength`: Maximum characters to return (optional)
+  - Inline images are surfaced (not dropped): `markdown` renders `![alt](contentUri "objectId=…")`; `text` emits a single-line `[image: objectId=… contentUri=… sourceUri=… size=WxHpt]` token. Pass the `objectId` to `getGoogleDocImage` to fetch the bytes. Floating/anchored (positioned) images are not surfaced.
 
 - **readGoogleDocPaginated** - Read a large Google Doc one page at a time (avoids host output-size truncation)
   - `documentId`: Document ID
@@ -642,12 +643,18 @@ Team mode is mutually exclusive with service-account and external-token modes, n
 - **getGoogleDocContent** - Get document content with text indices for formatting
   - `documentId`: Document ID
   - `includeFormatting`: Include font, style, and color info for each text span (optional, default: false)
+  - Inline images render as a single-line `[image: objectId=… contentUri=… sourceUri=… size=WxHpt]` token (was a bare `[image]`). Pass the `objectId` to `getGoogleDocImage`.
 
 - **getGoogleDocContentPaginated** - Paginated `getGoogleDocContent`; page ends snap to a line boundary where possible (a single line longer than `limit` is hard-cut to make forward progress)
   - `documentId`: Document ID
   - `includeFormatting`: Include font, style, and color info for each text span (optional, default: false)
   - `offset`: Character offset into the formatted output (optional, default: 0; pass the previous response's `nextOffset`)
   - `limit`: Maximum characters per page (optional, default: 50000, max: 80000)
+
+- **getGoogleDocImage** - Fetch the bytes of an inline image embedded in a Google Doc, keyed by its inline object ID (the doc is re-fetched so the underlying image URL is always fresh). Inline images only; floating/anchored (positioned) images are not supported.
+  - `documentId`: Document ID
+  - `inlineObjectId`: The inline object ID shown in `readGoogleDoc` / `getGoogleDocContent` image placeholders (the `objectId=…` value, e.g. `kix.abc123`)
+  - `outputFormat`: `image` (default) returns a native image the model can view; `base64` returns a `{ inlineObjectId, mimeType, byteLength, dataBase64 }` JSON envelope for programmatic use (forwarding, save-to-disk)
 
 - **listDocumentTabs** - List all tabs in a Google Doc with their IDs and hierarchy
   - `documentId`: Document ID

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -12,6 +12,11 @@ import { withRetry } from '../utils/retry.js';
 // Helper functions
 // ---------------------------------------------------------------------------
 
+// Upper bound on an inline image returned by getGoogleDocImage. Enforced up
+// front via the request's maxContentLength (so an oversized body is aborted
+// mid-download) and re-checked against the buffer as a backstop.
+const MAX_IMAGE_BYTES = 40 * 1024 * 1024;
+
 // Pure helper – no context needed
 function hexToRgbColor(hex: string): { red: number; green: number; blue: number } | null {
   if (!hex) return null;
@@ -73,6 +78,14 @@ function escapeBrackets(s: string): string {
   return s.replace(/[\[\]]/g, '\\$&');
 }
 
+// Percent-encode the characters that would break a Markdown link destination
+// `![alt](uri "title")` — spaces and parentheses (plus any stray control chars).
+function escapeMarkdownUri(uri: string): string {
+  return uri.replace(/[\s()]/g, (c) =>
+    c === '(' ? '%28' : c === ')' ? '%29' : encodeURIComponent(c)
+  );
+}
+
 // Normalized view of an inline image, resolved from the document's inlineObjects
 // map. Returns null when the map is absent or has no entry for the id (callers
 // fall back to a bare `[image]` placeholder).
@@ -95,7 +108,9 @@ function getInlineImageMeta(inlineObjectId: string, inlineObjects?: any): Inline
   if (img?.contentUri) meta.contentUri = img.contentUri;
   if (img?.sourceUri) meta.sourceUri = img.sourceUri;
   const alt = embedded?.description || embedded?.title;
-  if (alt) meta.altText = alt;
+  // Collapse newlines/CR (and surrounding whitespace) to a single space so the
+  // single-line placeholder invariant holds even for multi-line alt text.
+  if (alt) meta.altText = String(alt).replace(/\s*[\r\n]+\s*/g, ' ');
   const w = embedded?.size?.width?.magnitude;
   const h = embedded?.size?.height?.magnitude;
   if (w != null) meta.width = Math.round(w);
@@ -127,8 +142,10 @@ function renderImagePlaceholder(meta: InlineImageMeta | null): string {
   if (!meta) return '[image]';
   const parts: string[] = [`objectId=${meta.objectId}`];
   if (meta.altText) parts.push(`alt="${escapeBrackets(meta.altText).replace(/"/g, '\\"')}"`);
-  if (meta.contentUri) parts.push(`contentUri=${meta.contentUri}`);
-  if (meta.sourceUri) parts.push(`sourceUri=${meta.sourceUri}`);
+  // Bracket-escape the URIs too: a raw `]` in a source/content URL would
+  // otherwise prematurely close the `[image: ...]` delimiter.
+  if (meta.contentUri) parts.push(`contentUri=${escapeBrackets(meta.contentUri)}`);
+  if (meta.sourceUri) parts.push(`sourceUri=${escapeBrackets(meta.sourceUri)}`);
   if (meta.width != null && meta.height != null) {
     parts.push(`size=${meta.width}x${meta.height}${meta.unit || 'pt'}`);
   }
@@ -140,10 +157,14 @@ function renderImagePlaceholder(meta: InlineImageMeta | null): string {
 // single-line placeholder when no fetchable URI is available.
 function renderImageMarkdown(meta: InlineImageMeta | null): string {
   if (!meta) return '[image]';
-  const uri = meta.contentUri || meta.sourceUri;
+  // Prefer the durable original source URL. The Google contentUri is ephemeral
+  // (expires ~30 min), so embedding it in persisted markdown would 404; fall back
+  // to it only when there is no source URL. The durable objectId stays in the
+  // title slot for reliable re-fetch via getGoogleDocImage.
+  const uri = meta.sourceUri || meta.contentUri;
   if (!uri) return renderImagePlaceholder(meta);
   const alt = meta.altText ? escapeBrackets(meta.altText) : '';
-  return `![${alt}](${uri} "objectId=${meta.objectId}")`;
+  return `![${alt}](${escapeMarkdownUri(uri)} "objectId=${meta.objectId}")`;
 }
 
 // Extract plain text from body content (paragraphs + tables). Inline images are
@@ -727,6 +748,10 @@ function buildDocFormattedContent(
     text: string;
     startIndex: number;
     endIndex: number;
+    // True for inline replacements (images, persons, rich links, footnotes,
+    // rules) whose rendered text length is unrelated to their real doc span, so
+    // the displayed edit range must use [startIndex, endIndex), not text length.
+    atomic?: boolean;
     fontFamily?: string;
     fontSize?: number;
     bold?: boolean;
@@ -808,6 +833,7 @@ function buildDocFormattedContent(
                   text: inlineText,
                   startIndex: textElement.startIndex,
                   endIndex: textElement.endIndex,
+                  atomic: true,
                 });
               }
             }
@@ -849,6 +875,19 @@ function buildDocFormattedContent(
     for (const segment of segments) {
       const hasMeta = withFormatting && hasFormattingInfo(segment);
       const meta = hasMeta ? buildMetaLine(segment) : null;
+      // Atomic inline replacements occupy exactly [startIndex, endIndex) in the
+      // doc regardless of how long their placeholder text is. Emit that real
+      // range on one line so index-based edits target the object, not the text
+      // that follows it.
+      if (segment.atomic) {
+        const line = segment.text.replace(/\n/g, ' ').trim();
+        if (line) {
+          result += meta
+            ? `[${segment.startIndex}-${segment.endIndex}] ${meta}\n  ${line}\n`
+            : `[${segment.startIndex}-${segment.endIndex}] ${line}\n`;
+        }
+        continue;
+      }
       const lines = segment.text.split('\n');
       let offset = segment.startIndex;
       for (const line of lines) {
@@ -2299,20 +2338,35 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       }
       const contentUri = embedded.imageProperties?.contentUri;
       if (!contentUri) {
+        // An image inserted from a URL exposes only sourceUri (an external URL).
+        // We deliberately don't fetch it server-side (that would send Google
+        // credentials to a third-party host), so surface the URL instead of the
+        // misleading "embedded chart or drawing" message the readers contradict.
+        const sourceUri = embedded.imageProperties?.sourceUri;
+        if (sourceUri) {
+          return errorResponse(
+            `Inline object "${a.inlineObjectId}" has no Google-hosted image to fetch; it references an external source URL that this tool does not retrieve: ${sourceUri} — fetch it directly.`
+          );
+        }
         return errorResponse(
           `Inline object "${a.inlineObjectId}" has no fetchable image content (e.g. an embedded chart or drawing rather than a raster image).`
         );
       }
 
       // Authenticated fetch of the (fresh) contentUri — same primitive used for
-      // Drive export links elsewhere in this codebase.
-      const resp = await ctx.authClient.request({ url: contentUri, responseType: 'arraybuffer' });
+      // Drive export links elsewhere in this codebase. maxContentLength aborts an
+      // oversized body mid-download rather than buffering it all first; the
+      // byteLength check below is a backstop for responses lacking Content-Length.
+      const resp = await ctx.authClient.request({
+        url: contentUri,
+        responseType: 'arraybuffer',
+        maxContentLength: MAX_IMAGE_BYTES,
+      });
       const buffer = Buffer.from(resp.data as ArrayBuffer);
 
-      const MAX_IMAGE_BYTES = 40 * 1024 * 1024;
       if (buffer.byteLength > MAX_IMAGE_BYTES) {
         return errorResponse(
-          `Image is too large to return inline (${Math.round(buffer.byteLength / (1024 * 1024))} MB, limit 40 MB).`
+          `Image is too large to return inline (${(buffer.byteLength / (1024 * 1024)).toFixed(1)} MB, limit 40 MB).`
         );
       }
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -67,14 +67,106 @@ function findTabById(tabs: any[], targetId: string): any | null {
   return null;
 }
 
-// Extract plain text from body content (paragraphs + tables)
-function extractText(bodyContent: any[]): string {
+// Escape square brackets so bracket-delimited placeholders / markdown links
+// remain unambiguous when the payload itself contains `[` or `]`.
+function escapeBrackets(s: string): string {
+  return s.replace(/[\[\]]/g, '\\$&');
+}
+
+// Normalized view of an inline image, resolved from the document's inlineObjects
+// map. Returns null when the map is absent or has no entry for the id (callers
+// fall back to a bare `[image]` placeholder).
+interface InlineImageMeta {
+  objectId: string;
+  contentUri?: string;
+  sourceUri?: string;
+  altText?: string;
+  width?: number;
+  height?: number;
+  unit?: string;
+}
+
+function getInlineImageMeta(inlineObjectId: string, inlineObjects?: any): InlineImageMeta | null {
+  const obj = inlineObjects?.[inlineObjectId];
+  if (!obj) return null;
+  const embedded = obj.inlineObjectProperties?.embeddedObject;
+  const meta: InlineImageMeta = { objectId: inlineObjectId };
+  const img = embedded?.imageProperties;
+  if (img?.contentUri) meta.contentUri = img.contentUri;
+  if (img?.sourceUri) meta.sourceUri = img.sourceUri;
+  const alt = embedded?.description || embedded?.title;
+  if (alt) meta.altText = alt;
+  const w = embedded?.size?.width?.magnitude;
+  const h = embedded?.size?.height?.magnitude;
+  if (w != null) meta.width = Math.round(w);
+  if (h != null) meta.height = Math.round(h);
+  const unit = embedded?.size?.width?.unit || embedded?.size?.height?.unit;
+  if (unit) meta.unit = String(unit).toLowerCase();
+  return meta;
+}
+
+// Locate an inline object's embeddedObject by id across the whole document —
+// every tab's inlineObjects map plus the legacy single-body map. Returns the
+// embeddedObject (which carries imageProperties) or null when not found.
+function findInlineObjectById(doc: any, inlineObjectId: string): any | null {
+  const fromMap = (m: any) => m?.[inlineObjectId]?.inlineObjectProperties?.embeddedObject;
+  const tabs = doc.tabs as any[] | undefined;
+  if (tabs && tabs.length > 0) {
+    for (const { tab } of collectAllTabsWithLevel(tabs)) {
+      const embedded = fromMap(tab.documentTab?.inlineObjects);
+      if (embedded) return embedded;
+    }
+  }
+  return fromMap(doc.inlineObjects) || null;
+}
+
+// Single-line, self-describing image placeholder used by the text and indexed
+// readers. Deliberately contains no newline (keeps index/pagination math intact)
+// and no unescaped `|` (keeps table-cell escaping from mangling it).
+function renderImagePlaceholder(meta: InlineImageMeta | null): string {
+  if (!meta) return '[image]';
+  const parts: string[] = [`objectId=${meta.objectId}`];
+  if (meta.altText) parts.push(`alt="${escapeBrackets(meta.altText).replace(/"/g, '\\"')}"`);
+  if (meta.contentUri) parts.push(`contentUri=${meta.contentUri}`);
+  if (meta.sourceUri) parts.push(`sourceUri=${meta.sourceUri}`);
+  if (meta.width != null && meta.height != null) {
+    parts.push(`size=${meta.width}x${meta.height}${meta.unit || 'pt'}`);
+  }
+  return `[image: ${parts.join(' ')}]`;
+}
+
+// Markdown rendering: a real `![alt](uri)` carrying the durable objectId in the
+// title slot so the caller can pass it to getGoogleDocImage. Falls back to the
+// single-line placeholder when no fetchable URI is available.
+function renderImageMarkdown(meta: InlineImageMeta | null): string {
+  if (!meta) return '[image]';
+  const uri = meta.contentUri || meta.sourceUri;
+  if (!uri) return renderImagePlaceholder(meta);
+  const alt = meta.altText ? escapeBrackets(meta.altText) : '';
+  return `![${alt}](${uri} "objectId=${meta.objectId}")`;
+}
+
+// Extract plain text from body content (paragraphs + tables). Inline images are
+// rendered from `inlineObjects` (markdown `![alt](uri)` or a single-line
+// placeholder) instead of being dropped.
+function extractText(
+  bodyContent: any[],
+  inlineObjects?: any,
+  format: 'text' | 'markdown' = 'text'
+): string {
+  const renderImage = (id: string): string =>
+    format === 'markdown'
+      ? renderImageMarkdown(getInlineImageMeta(id, inlineObjects))
+      : renderImagePlaceholder(getInlineImageMeta(id, inlineObjects));
+
   let result = '';
   for (const element of bodyContent) {
     if (element.paragraph?.elements) {
       for (const elem of element.paragraph.elements) {
         if (elem.textRun?.content) {
           result += elem.textRun.content;
+        } else if (elem.inlineObjectElement?.inlineObjectId) {
+          result += renderImage(elem.inlineObjectElement.inlineObjectId);
         }
       }
     } else if (element.table) {
@@ -85,6 +177,8 @@ function extractText(bodyContent: any[]): string {
               for (const elem of cellContent.paragraph.elements) {
                 if (elem.textRun?.content) {
                   result += elem.textRun.content;
+                } else if (elem.inlineObjectElement?.inlineObjectId) {
+                  result += renderImage(elem.inlineObjectElement.inlineObjectId);
                 }
               }
             }
@@ -99,7 +193,11 @@ function extractText(bodyContent: any[]): string {
 }
 
 // Extract full text from a Google Doc, handling tabs and optional tabId filtering
-function extractDocText(doc: any, tabId?: string): { text: string; error?: string } {
+function extractDocText(
+  doc: any,
+  tabId?: string,
+  format: 'text' | 'markdown' = 'text'
+): { text: string; error?: string } {
   let text = '';
   const tabs = doc.tabs as any[] | undefined;
 
@@ -111,7 +209,7 @@ function extractDocText(doc: any, tabId?: string): { text: string; error?: strin
       }
       const bodyContent = tab.documentTab?.body?.content;
       if (bodyContent) {
-        text = extractText(bodyContent);
+        text = extractText(bodyContent, tab.documentTab?.inlineObjects, format);
       }
     } else {
       const allTabs = collectAllTabsWithLevel(tabs);
@@ -124,7 +222,7 @@ function extractDocText(doc: any, tabId?: string): { text: string; error?: strin
           text += `${indent}=== Tab: ${title} ===\n`;
         }
         if (bodyContent) {
-          text += extractText(bodyContent);
+          text += extractText(bodyContent, tab.documentTab?.inlineObjects, format);
         }
         if (isMultiTab) {
           text += '\n';
@@ -134,7 +232,7 @@ function extractDocText(doc: any, tabId?: string): { text: string; error?: strin
   } else {
     const body = doc.body;
     if (body?.content) {
-      text = extractText(body.content);
+      text = extractText(body.content, doc.inlineObjects, format);
     }
   }
 
@@ -647,18 +745,12 @@ function buildDocFormattedContent(
     }
     if (el.richLink?.richLinkProperties) {
       const rl = el.richLink.richLinkProperties;
-      const title = (rl.title || rl.uri || '').replace(/[\[\]]/g, '\\$&');
+      const title = escapeBrackets(rl.title || rl.uri || '');
       const uri = rl.uri;
       return title && uri ? `[${title}](${uri})` : title || null;
     }
     if (el.inlineObjectElement?.inlineObjectId) {
-      if (inlineObjects) {
-        const obj = inlineObjects[el.inlineObjectElement.inlineObjectId];
-        const desc = obj?.inlineObjectProperties?.embeddedObject?.description
-                  || obj?.inlineObjectProperties?.embeddedObject?.title;
-        return desc ? `[image: ${desc}]` : '[image]';
-      }
-      return '[image]';
+      return renderImagePlaceholder(getInlineImageMeta(el.inlineObjectElement.inlineObjectId, inlineObjects));
     }
     if (el.footnoteReference) {
       return `[^${el.footnoteReference.footnoteNumber || ''}]`;
@@ -1114,6 +1206,12 @@ const UpdateGoogleDocSchema = z.object({
 const GetGoogleDocContentSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
   includeFormatting: z.boolean().optional(),
+});
+
+const GetGoogleDocImageSchema = z.object({
+  documentId: z.string().min(1, "Document ID is required"),
+  inlineObjectId: z.string().min(1, "Inline object ID is required"),
+  outputFormat: z.enum(['image', 'base64']).optional().default('image'),
 });
 
 const InsertTextSchema = z.object({
@@ -1680,6 +1778,19 @@ export const toolDefinitions: ToolDefinition[] = [
     }
   },
   {
+    name: "getGoogleDocImage",
+    description: "Fetch the bytes of an inline image embedded in a Google Doc, keyed by its inline object ID. Returns a native image the model can see (or base64). The doc is re-fetched so the underlying image URL is always fresh — pass the objectId, never a raw contentUri (those expire). Inline images only; floating/anchored images are not supported.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        documentId: { type: "string", description: "Document ID" },
+        inlineObjectId: { type: "string", description: "The inline object ID shown in readGoogleDoc / getGoogleDocContent image placeholders (the objectId=... value, e.g. \"kix.abc123\")" },
+        outputFormat: { type: "string", enum: ["image", "base64"], description: "\"image\" (default) returns a native MCP image block the model can view; \"base64\" returns a JSON envelope { inlineObjectId, mimeType, byteLength, dataBase64 } for programmatic use (forwarding, save-to-disk)" }
+      },
+      required: ["documentId", "inlineObjectId"]
+    }
+  },
+  {
     name: "insertTable",
     description: "Insert a new table with the specified dimensions at a given index. For multi-tab docs, specify tabId to target a specific tab.",
     inputSchema: {
@@ -2166,6 +2277,68 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       };
     }
 
+    case "getGoogleDocImage": {
+      const validation = GetGoogleDocImageSchema.safeParse(args);
+      if (!validation.success) {
+        return errorResponse(validation.error.errors[0].message);
+      }
+      const a = validation.data;
+
+      const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
+      // Re-fetch the doc so the resolved contentUri is fresh (they expire ~30 min).
+      const docResponse = await docs.documents.get({
+        documentId: a.documentId,
+        includeTabsContent: true,
+      });
+
+      const embedded = findInlineObjectById(docResponse.data, a.inlineObjectId);
+      if (!embedded) {
+        return errorResponse(
+          `Inline object "${a.inlineObjectId}" not found in document. Use readGoogleDoc or getGoogleDocContent to list valid inline image objectIds.`
+        );
+      }
+      const contentUri = embedded.imageProperties?.contentUri;
+      if (!contentUri) {
+        return errorResponse(
+          `Inline object "${a.inlineObjectId}" has no fetchable image content (e.g. an embedded chart or drawing rather than a raster image).`
+        );
+      }
+
+      // Authenticated fetch of the (fresh) contentUri — same primitive used for
+      // Drive export links elsewhere in this codebase.
+      const resp = await ctx.authClient.request({ url: contentUri, responseType: 'arraybuffer' });
+      const buffer = Buffer.from(resp.data as ArrayBuffer);
+
+      const MAX_IMAGE_BYTES = 40 * 1024 * 1024;
+      if (buffer.byteLength > MAX_IMAGE_BYTES) {
+        return errorResponse(
+          `Image is too large to return inline (${Math.round(buffer.byteLength / (1024 * 1024))} MB, limit 40 MB).`
+        );
+      }
+
+      const rawContentType = (resp.headers?.['content-type'] as string | undefined) || 'application/octet-stream';
+      const mimeType = rawContentType.split(';')[0].trim();
+      const dataBase64 = buffer.toString('base64');
+
+      if (a.outputFormat === 'base64') {
+        const envelope = {
+          inlineObjectId: a.inlineObjectId,
+          mimeType,
+          byteLength: buffer.byteLength,
+          dataBase64,
+        };
+        return {
+          content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
+          isError: false
+        };
+      }
+
+      return {
+        content: [{ type: "image", data: dataBase64, mimeType }],
+        isError: false
+      };
+    }
+
     // =========================================================================
     // DOC EDITING TOOLS
     // =========================================================================
@@ -2359,7 +2532,7 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
         };
       }
 
-      const { text, error } = extractDocText(doc, a.tabId);
+      const { text, error } = extractDocText(doc, a.tabId, format === 'markdown' ? 'markdown' : 'text');
       if (error) {
         return errorResponse(error);
       }
@@ -2395,7 +2568,7 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       const doc = docResponse.data;
       const format = a.format || 'text';
 
-      const { text, error } = extractDocText(doc, a.tabId);
+      const { text, error } = extractDocText(doc, a.tabId, format === 'markdown' ? 'markdown' : 'text');
       if (error) {
         return errorResponse(error);
       }

--- a/src/tools/toolMeta.ts
+++ b/src/tools/toolMeta.ts
@@ -90,6 +90,7 @@ export const TOOL_META: Record<string, ToolMeta> = {
   getComment: read(DRIVE_READ_SCOPES),
   getGoogleDocContent: read(DOCS_READ_SCOPES),
   getGoogleDocContentPaginated: read(DOCS_READ_SCOPES),
+  getGoogleDocImage: read(DOCS_READ_SCOPES),
   listGoogleDocs: read(DRIVE_READ_SCOPES),
   getDocumentInfo: read(DOCS_READ_SCOPES),
   readSmartChips: read(DOCS_READ_SCOPES),

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,10 @@ import type {
 
 export interface ToolResult {
   [key: string]: unknown;
-  content: Array<{ type: string; text: string }>;
+  // `text` blocks carry a string; `image` blocks carry base64 `data` + `mimeType`
+  // (an MCP image content block). Kept as a single widened shape for backward
+  // compatibility with the many `{ type: "text", text }` construction sites.
+  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
   isError?: boolean;
 }
 

--- a/test/helpers/setup-server.ts
+++ b/test/helpers/setup-server.ts
@@ -82,7 +82,7 @@ export async function callTool(
   client: Client,
   name: string,
   args: Record<string, unknown> = {},
-): Promise<{ content: Array<{ type: string; text: string; data?: string; mimeType?: string }>; isError?: boolean }> {
+): Promise<{ content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean }> {
   const result = await client.callTool({ name, arguments: args });
   return result as any;
 }

--- a/test/helpers/setup-server.ts
+++ b/test/helpers/setup-server.ts
@@ -17,7 +17,13 @@ export interface TestContext {
   client: Client;
   mocks: AllMocks;
   cleanup: () => Promise<void>;
+  /** Override the injected auth client's `request` (used by tools that fetch
+   *  arbitrary URLs, e.g. getGoogleDocImage). Restore with `resetAuthRequest`. */
+  setAuthRequest: (fn: (opts: any) => Promise<any>) => void;
+  resetAuthRequest: () => void;
 }
+
+const DEFAULT_AUTH_REQUEST = async () => ({ data: 'mock-auth-request-response' });
 
 // We cache the server module so it's only imported once across all test files.
 let _serverModule: any = null;
@@ -37,10 +43,13 @@ export async function setupTestServer(): Promise<TestContext> {
     _serverModule = await import('../../src/index.js');
   }
 
-  // Inject fake auth client to bypass authenticate()
-  _serverModule._setAuthClientForTesting({
-    request: async () => ({ data: 'mock-auth-request-response' }),
-  });
+  // Inject fake auth client to bypass authenticate(). The object is mutable and
+  // held by reference inside the server, so swapping `.request` here is visible
+  // to `ctx.authClient.request` in tool handlers.
+  const authClientMock: { request: (opts: any) => Promise<any> } = {
+    request: DEFAULT_AUTH_REQUEST,
+  };
+  _serverModule._setAuthClientForTesting(authClientMock);
 
   const server = _serverModule.server;
 
@@ -60,7 +69,10 @@ export async function setupTestServer(): Promise<TestContext> {
     // The serverTransport closing is enough to reset the connection.
   };
 
-  return { client, mocks, cleanup };
+  const setAuthRequest = (fn: (opts: any) => Promise<any>) => { authClientMock.request = fn; };
+  const resetAuthRequest = () => { authClientMock.request = DEFAULT_AUTH_REQUEST; };
+
+  return { client, mocks, cleanup, setAuthRequest, resetAuthRequest };
 }
 
 /**
@@ -70,7 +82,7 @@ export async function callTool(
   client: Client,
   name: string,
   args: Record<string, unknown> = {},
-): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+): Promise<{ content: Array<{ type: string; text: string; data?: string; mimeType?: string }>; isError?: boolean }> {
   const result = await client.callTool({ name, arguments: args });
   return result as any;
 }

--- a/test/integration/calendar.test.ts
+++ b/test/integration/calendar.test.ts
@@ -16,14 +16,14 @@ describe('Calendar tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'listCalendars', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('My Calendar'));
+      assert.ok(res.content[0].text!.includes('My Calendar'));
     });
 
     it('propagates API error', async () => {
       ctx.mocks.calendar.service.calendarList.list._setImpl(async () => { throw new Error('Cal API down'); });
       const res = await callTool(ctx.client, 'listCalendars', {});
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('Cal API down'));
+      assert.ok(res.content[0].text!.includes('Cal API down'));
       ctx.mocks.calendar.service.calendarList.list._resetImpl();
     });
   });
@@ -33,15 +33,15 @@ describe('Calendar tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'getCalendarEvents', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Test Event'));
+      assert.ok(res.content[0].text!.includes('Test Event'));
     });
 
     it('surfaces attachments for listed events', async () => {
       const res = await callTool(ctx.client, 'getCalendarEvents', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Attachments:'));
-      assert.ok(res.content[0].text.includes('Agenda.pdf'));
-      assert.ok(res.content[0].text.includes('https://drive.google.com/file/d/file-1/view'));
+      assert.ok(res.content[0].text!.includes('Attachments:'));
+      assert.ok(res.content[0].text!.includes('Agenda.pdf'));
+      assert.ok(res.content[0].text!.includes('https://drive.google.com/file/d/file-1/view'));
     });
   });
 
@@ -50,7 +50,7 @@ describe('Calendar tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'getCalendarEvent', { eventId: 'event-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Test Event'));
+      assert.ok(res.content[0].text!.includes('Test Event'));
     });
 
     it('validation error', async () => {
@@ -61,9 +61,9 @@ describe('Calendar tools', () => {
     it('surfaces attachments in the response', async () => {
       const res = await callTool(ctx.client, 'getCalendarEvent', { eventId: 'event-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Attachments:'));
-      assert.ok(res.content[0].text.includes('Agenda.pdf'));
-      assert.ok(res.content[0].text.includes('https://drive.google.com/file/d/file-1/view'));
+      assert.ok(res.content[0].text!.includes('Attachments:'));
+      assert.ok(res.content[0].text!.includes('Agenda.pdf'));
+      assert.ok(res.content[0].text!.includes('https://drive.google.com/file/d/file-1/view'));
     });
 
     it('renders a title-less attachment without duplicating the URL', async () => {
@@ -80,8 +80,8 @@ describe('Calendar tools', () => {
       const res = await callTool(ctx.client, 'getCalendarEvent', { eventId: 'event-1' });
       ctx.mocks.calendar.service.events.get._resetImpl();
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Attachments: https://example.com/f'));
-      assert.ok(!res.content[0].text.includes('https://example.com/f (https://example.com/f)'));
+      assert.ok(res.content[0].text!.includes('Attachments: https://example.com/f'));
+      assert.ok(!res.content[0].text!.includes('https://example.com/f (https://example.com/f)'));
     });
   });
 
@@ -94,7 +94,7 @@ describe('Calendar tools', () => {
         end: { dateTime: '2025-06-01T11:00:00Z' },
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('created'));
+      assert.ok(res.content[0].text!.includes('created'));
     });
 
     it('validation error', async () => {
@@ -136,7 +136,7 @@ describe('Calendar tools', () => {
         eventId: 'event-1', summary: 'Updated Event',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('updated'));
+      assert.ok(res.content[0].text!.includes('updated'));
     });
 
     it('validation error', async () => {
@@ -186,7 +186,7 @@ describe('Calendar tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'deleteCalendarEvent', { eventId: 'event-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('deleted'));
+      assert.ok(res.content[0].text!.includes('deleted'));
     });
 
     it('validation error', async () => {

--- a/test/integration/docs-from-html.test.ts
+++ b/test/integration/docs-from-html.test.ts
@@ -42,8 +42,8 @@ describe('createDocFromHTML', () => {
     });
 
     assert.equal(res.isError, false);
-    assert.ok(res.content[0].text.includes('Created Google Doc from HTML'));
-    assert.ok(res.content[0].text.includes('html-doc-1'));
+    assert.ok(res.content[0].text!.includes('Created Google Doc from HTML'));
+    assert.ok(res.content[0].text!.includes('html-doc-1'));
 
     // Verify files.create was called with text/html media mimeType
     const createCalls = ctx.mocks.drive.tracker.getCalls('files.create');
@@ -65,8 +65,8 @@ describe('createDocFromHTML', () => {
     });
 
     assert.equal(res.isError, true);
-    assert.ok(res.content[0].text.includes('already exists'));
-    assert.ok(res.content[0].text.includes('existing-doc-99'));
+    assert.ok(res.content[0].text!.includes('already exists'));
+    assert.ok(res.content[0].text!.includes('existing-doc-99'));
   });
 
   it('validation error for missing html', async () => {
@@ -105,7 +105,7 @@ describe('createDocFromHTML', () => {
 
     // Collision in a different folder did not block creation.
     assert.equal(res.isError, false);
-    assert.ok(res.content[0].text.includes('html-doc-2'));
+    assert.ok(res.content[0].text!.includes('html-doc-2'));
 
     // parentFolderId resolved (plain ID passthrough) and flowed into files.create.
     const createArg = ctx.mocks.drive.tracker.getCalls('files.create').at(-1)!.args[0];

--- a/test/integration/docs-listing.test.ts
+++ b/test/integration/docs-listing.test.ts
@@ -25,7 +25,7 @@ describe('Docs listing tools', () => {
       }));
       const res = await callTool(ctx.client, 'listGoogleDocs', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('My Document'));
+      assert.ok(res.content[0].text!.includes('My Document'));
     });
 
     it('passes corpora=allDrives so shared-drive docs are listed', async () => {
@@ -43,7 +43,7 @@ describe('Docs listing tools', () => {
       ctx.mocks.drive.service.files.list._setImpl(async () => ({ data: { files: [] } }));
       const res = await callTool(ctx.client, 'listGoogleDocs', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('No Google Docs'));
+      assert.ok(res.content[0].text!.includes('No Google Docs'));
     });
   });
 
@@ -60,7 +60,7 @@ describe('Docs listing tools', () => {
       }));
       const res = await callTool(ctx.client, 'getDocumentInfo', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('My Document'));
+      assert.ok(res.content[0].text!.includes('My Document'));
     });
 
     it('passes supportsAllDrives so shared-drive documents resolve', async () => {

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -609,6 +609,165 @@ describe('Docs tools', () => {
       const res = await callTool(ctx.client, 'readGoogleDoc', {});
       assert.equal(res.isError, true);
     });
+
+    it('renders inline images as markdown with objectId in title (format=markdown)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with image',
+          body: {
+            content: [{
+              paragraph: {
+                elements: [
+                  { inlineObjectElement: { inlineObjectId: 'obj-1' } },
+                  { textRun: { content: '\n' } },
+                ],
+              },
+            }],
+          },
+          inlineObjects: {
+            'obj-1': {
+              inlineObjectProperties: {
+                embeddedObject: {
+                  description: 'Architecture diagram',
+                  imageProperties: { contentUri: 'https://lh3.googleusercontent.com/xyz' },
+                },
+              },
+            },
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text!.includes('![Architecture diagram](https://lh3.googleusercontent.com/xyz "objectId=obj-1")'), res.content[0].text);
+    });
+
+    it('renders inline images as a single-line placeholder (format=text)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with image',
+          body: {
+            content: [{
+              paragraph: {
+                elements: [
+                  { textRun: { content: 'Before ' } },
+                  { inlineObjectElement: { inlineObjectId: 'obj-1' } },
+                  { textRun: { content: ' after\n' } },
+                ],
+              },
+            }],
+          },
+          inlineObjects: {
+            'obj-1': {
+              inlineObjectProperties: {
+                embeddedObject: { imageProperties: { contentUri: 'https://lh3.googleusercontent.com/xyz' } },
+              },
+            },
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('[image: objectId=obj-1 contentUri=https://lh3.googleusercontent.com/xyz]'), text);
+      // no markdown syntax in text format
+      assert.ok(!text.includes('!['), 'text format should not emit markdown image syntax');
+    });
+
+    it('falls back to [image] when the inlineObjects map is missing', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with orphan image',
+          body: {
+            content: [{
+              paragraph: {
+                elements: [
+                  { inlineObjectElement: { inlineObjectId: 'obj-1' } },
+                  { textRun: { content: '\n' } },
+                ],
+              },
+            }],
+            // no inlineObjects map
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text!.includes('[image]'), res.content[0].text);
+    });
+
+    it('resolves a multi-tab image against the correct tab inlineObjects map', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Multi-tab image doc',
+          tabs: [
+            {
+              tabProperties: { tabId: 'tab-1', title: 'Tab1' },
+              documentTab: {
+                body: { content: [{ paragraph: { elements: [{ textRun: { content: 'First tab\n' } }] } }] },
+                inlineObjects: {},
+              },
+            },
+            {
+              tabProperties: { tabId: 'tab-2', title: 'Tab2' },
+              documentTab: {
+                body: {
+                  content: [{
+                    paragraph: {
+                      elements: [
+                        { inlineObjectElement: { inlineObjectId: 'obj-2' } },
+                        { textRun: { content: '\n' } },
+                      ],
+                    },
+                  }],
+                },
+                inlineObjects: {
+                  'obj-2': {
+                    inlineObjectProperties: {
+                      embeddedObject: { imageProperties: { contentUri: 'https://lh3.googleusercontent.com/tab2' } },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text!.includes('contentUri=https://lh3.googleusercontent.com/tab2'), res.content[0].text);
+    });
+
+    it('readGoogleDocPaginated carries inline images (proves format threading)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Paginated image doc',
+          body: {
+            content: [{
+              paragraph: {
+                elements: [
+                  { inlineObjectElement: { inlineObjectId: 'obj-1' } },
+                  { textRun: { content: '\n' } },
+                ],
+              },
+            }],
+          },
+          inlineObjects: {
+            'obj-1': {
+              inlineObjectProperties: {
+                embeddedObject: {
+                  description: 'Diagram',
+                  imageProperties: { contentUri: 'https://lh3.googleusercontent.com/xyz' },
+                },
+              },
+            },
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const envelope = JSON.parse(res.content[0].text!);
+      assert.ok(envelope.content.includes('![Diagram](https://lh3.googleusercontent.com/xyz "objectId=obj-1")'), envelope.content);
+    });
   });
 
   // --- listDocumentTabs ---
@@ -1122,7 +1281,7 @@ describe('Docs tools', () => {
       assert.ok(res.content[0].text.includes('[Design Doc](https://docs.google.com/doc/123)'));
     });
 
-    it('extracts inline images with description', async () => {
+    it('extracts inline images with description, uri, and size on one line', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({
         data: {
           documentId: 'doc-1',
@@ -1143,7 +1302,17 @@ describe('Docs tools', () => {
               inlineObjects: {
                 'obj-1': {
                   inlineObjectProperties: {
-                    embeddedObject: { description: 'Architecture diagram' },
+                    embeddedObject: {
+                      description: 'Architecture diagram',
+                      imageProperties: {
+                        contentUri: 'https://lh3.googleusercontent.com/xyz',
+                        sourceUri: 'https://example.com/a.png',
+                      },
+                      size: {
+                        width: { magnitude: 468, unit: 'PT' },
+                        height: { magnitude: 286, unit: 'PT' },
+                      },
+                    },
                   },
                 },
               },
@@ -1153,7 +1322,142 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('[image: Architecture diagram]'));
+      const text = res.content[0].text!;
+      // The whole image token must live on a single line.
+      const imageLine = text.split('\n').find(l => l.includes('objectId=obj-1'));
+      assert.ok(imageLine, 'image token should be present on one line');
+      assert.ok(imageLine!.includes('alt="Architecture diagram"'));
+      assert.ok(imageLine!.includes('contentUri=https://lh3.googleusercontent.com/xyz'));
+      assert.ok(imageLine!.includes('sourceUri=https://example.com/a.png'));
+      assert.ok(imageLine!.includes('size=468x286pt'));
+    });
+
+    it('surfaces sourceUri when contentUri is absent', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1',
+          title: 'Doc with source-only image',
+          tabs: [{
+            tabProperties: { title: 'Main' },
+            documentTab: {
+              body: {
+                content: [{
+                  paragraph: {
+                    elements: [
+                      { inlineObjectElement: { inlineObjectId: 'obj-1' }, startIndex: 0, endIndex: 1 },
+                      { textRun: { content: '\n' }, startIndex: 1, endIndex: 2 },
+                    ],
+                  },
+                }],
+              },
+              inlineObjects: {
+                'obj-1': {
+                  inlineObjectProperties: {
+                    embeddedObject: {
+                      imageProperties: { sourceUri: 'https://example.com/a.png' },
+                    },
+                  },
+                },
+              },
+            },
+          }],
+        },
+      }));
+      const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('sourceUri=https://example.com/a.png'));
+      assert.ok(!text.includes('contentUri='), 'contentUri should be omitted when absent');
+    });
+
+    it('escapes brackets and quotes in image alt text', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1',
+          title: 'Doc with bracketed alt',
+          tabs: [{
+            tabProperties: { title: 'Main' },
+            documentTab: {
+              body: {
+                content: [{
+                  paragraph: {
+                    elements: [
+                      { inlineObjectElement: { inlineObjectId: 'obj-1' }, startIndex: 0, endIndex: 1 },
+                      { textRun: { content: '\n' }, startIndex: 1, endIndex: 2 },
+                    ],
+                  },
+                }],
+              },
+              inlineObjects: {
+                'obj-1': {
+                  inlineObjectProperties: {
+                    embeddedObject: {
+                      description: 'Chart [v2] "final"',
+                      imageProperties: { contentUri: 'https://lh3.googleusercontent.com/xyz' },
+                    },
+                  },
+                },
+              },
+            },
+          }],
+        },
+      }));
+      const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('alt="Chart \\[v2\\] \\"final\\""'), `alt not escaped: ${text}`);
+    });
+
+    it('renders inline images inside table cells without embedded pipes', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1',
+          title: 'Doc with table image',
+          tabs: [{
+            tabProperties: { title: 'Main' },
+            documentTab: {
+              body: {
+                content: [{
+                  startIndex: 0,
+                  endIndex: 2,
+                  table: {
+                    tableRows: [{
+                      tableCells: [{
+                        content: [{
+                          paragraph: {
+                            elements: [
+                              { inlineObjectElement: { inlineObjectId: 'obj-1' }, startIndex: 1, endIndex: 2 },
+                            ],
+                          },
+                        }],
+                      }],
+                    }],
+                  },
+                }],
+              },
+              inlineObjects: {
+                'obj-1': {
+                  inlineObjectProperties: {
+                    embeddedObject: {
+                      imageProperties: { contentUri: 'https://lh3.googleusercontent.com/xyz' },
+                    },
+                  },
+                },
+              },
+            },
+          }],
+        },
+      }));
+      const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      const imageLine = text.split('\n').find(l => l.includes('objectId=obj-1'));
+      assert.ok(imageLine, 'image token should appear in the table row');
+      // The token itself (from `[image:` to its closing `]`) must contain no `|`,
+      // so it can't break the surrounding `| cell |` table structure.
+      const start = imageLine!.indexOf('[image:');
+      const token = imageLine!.slice(start, imageLine!.indexOf(']', start) + 1);
+      assert.ok(!token.includes('|'), `image token should not contain a pipe: ${token}`);
     });
 
     it('extracts footnote references', async () => {
@@ -1448,6 +1752,127 @@ describe('Docs tools', () => {
       const text = res.content[0].text;
       assert.ok(text.includes('Hello World'), 'multi-paragraph cell should join with space');
       assert.ok(!text.includes('HelloWorld'), 'paragraphs should not be concatenated without separator');
+    });
+  });
+
+  // --- getGoogleDocImage ---
+  describe('getGoogleDocImage', () => {
+    const PNG_BYTES = Buffer.from('89504e470d0a1a0a', 'hex'); // PNG signature, stand-in bytes
+    // Exact ArrayBuffer (Buffer.from(...).buffer is a shared/pooled 8KB buffer).
+    const pngArrayBuffer = () => new Uint8Array(PNG_BYTES).buffer;
+    const imageDocData = {
+      documentId: 'doc-1', title: 'Doc with image',
+      body: {
+        content: [{
+          paragraph: { elements: [{ inlineObjectElement: { inlineObjectId: 'obj-1' } }] },
+        }],
+      },
+      inlineObjects: {
+        'obj-1': {
+          inlineObjectProperties: {
+            embeddedObject: { imageProperties: { contentUri: 'https://lh3.googleusercontent.com/xyz' } },
+          },
+        },
+      },
+    };
+
+    afterEach(() => {
+      ctx.resetAuthRequest();
+    });
+
+    it('returns a native MCP image block by default', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
+      let requestedUrl = '';
+      ctx.setAuthRequest(async (opts: any) => {
+        requestedUrl = opts.url;
+        return { data: pngArrayBuffer(), headers: { 'content-type': 'image/png' } };
+      });
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
+      assert.equal(res.isError, false);
+      assert.equal(requestedUrl, 'https://lh3.googleusercontent.com/xyz');
+      assert.equal(res.content[0].type, 'image');
+      assert.equal(res.content[0].mimeType, 'image/png');
+      assert.equal(res.content[0].data, PNG_BYTES.toString('base64'));
+    });
+
+    it('strips charset from the content-type header', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
+      ctx.setAuthRequest(async () => ({ data: pngArrayBuffer(), headers: { 'content-type': 'image/jpeg; charset=binary' } }));
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
+      assert.equal(res.isError, false);
+      assert.equal(res.content[0].mimeType, 'image/jpeg');
+    });
+
+    it('returns a base64 JSON envelope when outputFormat=base64', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
+      ctx.setAuthRequest(async () => ({ data: pngArrayBuffer(), headers: { 'content-type': 'image/png' } }));
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1', outputFormat: 'base64' });
+      assert.equal(res.isError, false);
+      assert.equal(res.content[0].type, 'text');
+      const envelope = JSON.parse(res.content[0].text!);
+      assert.equal(envelope.inlineObjectId, 'obj-1');
+      assert.equal(envelope.mimeType, 'image/png');
+      assert.equal(envelope.byteLength, PNG_BYTES.byteLength);
+      assert.equal(envelope.dataBase64, PNG_BYTES.toString('base64'));
+    });
+
+    it('resolves an inline object from a multi-tab document', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Multi-tab image doc',
+          tabs: [
+            { tabProperties: { tabId: 'tab-1', title: 'Tab1' }, documentTab: { body: { content: [] }, inlineObjects: {} } },
+            {
+              tabProperties: { tabId: 'tab-2', title: 'Tab2' },
+              documentTab: {
+                body: { content: [] },
+                inlineObjects: {
+                  'obj-2': {
+                    inlineObjectProperties: {
+                      embeddedObject: { imageProperties: { contentUri: 'https://lh3.googleusercontent.com/tab2' } },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }));
+      let requestedUrl = '';
+      ctx.setAuthRequest(async (opts: any) => {
+        requestedUrl = opts.url;
+        return { data: pngArrayBuffer(), headers: { 'content-type': 'image/png' } };
+      });
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-2' });
+      assert.equal(res.isError, false);
+      assert.equal(requestedUrl, 'https://lh3.googleusercontent.com/tab2');
+    });
+
+    it('errors when the inlineObjectId is not found', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'nope' });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text!.includes('not found'));
+    });
+
+    it('errors when the inline object has no fetchable image content', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with chart',
+          body: { content: [] },
+          inlineObjects: {
+            'obj-1': { inlineObjectProperties: { embeddedObject: { title: 'A chart' } } },
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text!.includes('no fetchable image content'));
+    });
+
+    it('validation error when inlineObjectId is missing', async () => {
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1' });
+      assert.equal(res.isError, true);
     });
   });
 

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -135,7 +135,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'createGoogleDoc', { name: 'My Doc', content: 'Hello' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('My Doc'));
+      assert.ok(res.content[0].text!.includes('My Doc'));
     });
 
     it('validation error', async () => {
@@ -155,7 +155,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'updateGoogleDoc', { documentId: 'doc-1', content: 'New content' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Updated Google Doc'));
+      assert.ok(res.content[0].text!.includes('Updated Google Doc'));
 
       // Non-tabId path: still two separate batchUpdate calls (existing behavior).
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
@@ -174,7 +174,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'updateGoogleDoc', { documentId: 'doc-1', content: 'New tab content', tabId: 'tab-2' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('tab: tab-2'));
+      assert.ok(res.content[0].text!.includes('tab: tab-2'));
 
       // Verify documents.get was called with includeTabsContent.
       const getCalls = ctx.mocks.docs.tracker.getCalls('documents.get');
@@ -251,8 +251,8 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'updateGoogleDoc', { documentId: 'doc-1', content: 'x', tabId: 'missing' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('Tab with ID "missing" not found'));
-      assert.ok(res.content[0].text.includes('listDocumentTabs'));
+      assert.ok(res.content[0].text!.includes('Tab with ID "missing" not found'));
+      assert.ok(res.content[0].text!.includes('listDocumentTabs'));
 
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
       assert.equal(calls.length, 0);
@@ -275,13 +275,13 @@ describe('Docs tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'insertText', { documentId: 'doc-1', text: 'inserted', index: 1 });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('inserted'));
+      assert.ok(res.content[0].text!.includes('inserted'));
     });
 
     it('with tabId forwards tabId to Location', async () => {
       const res = await callTool(ctx.client, 'insertText', { documentId: 'doc-1', text: 'hello', index: 1, tabId: 'tab-7' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('tab-7'));
+      assert.ok(res.content[0].text!.includes('tab-7'));
 
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
       const lastCall = calls[calls.length - 1];
@@ -295,7 +295,7 @@ describe('Docs tools', () => {
     it('rejects index 0 on a Google Doc (1-based)', async () => {
       const res = await callTool(ctx.client, 'insertText', { documentId: 'doc-1', text: 'x', index: 0 });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('1-based'));
+      assert.ok(res.content[0].text!.includes('1-based'));
     });
 
     it('validation error', async () => {
@@ -315,13 +315,13 @@ describe('Docs tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'deleteRange', { documentId: 'doc-1', startIndex: 1, endIndex: 5 });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('deleted'));
+      assert.ok(res.content[0].text!.includes('deleted'));
     });
 
     it('with tabId forwards tabId to Range', async () => {
       const res = await callTool(ctx.client, 'deleteRange', { documentId: 'doc-1', startIndex: 1, endIndex: 5, tabId: 'tab-7' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('tab-7'));
+      assert.ok(res.content[0].text!.includes('tab-7'));
 
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
       const lastCall = calls[calls.length - 1];
@@ -335,13 +335,13 @@ describe('Docs tools', () => {
     it('validation: endIndex must be > startIndex', async () => {
       const res = await callTool(ctx.client, 'deleteRange', { documentId: 'doc-1', startIndex: 5, endIndex: 2 });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.toLowerCase().includes('end index'));
+      assert.ok(res.content[0].text!.toLowerCase().includes('end index'));
     });
 
     it('rejects startIndex 0 on a Google Doc (1-based)', async () => {
       const res = await callTool(ctx.client, 'deleteRange', { documentId: 'doc-1', startIndex: 0, endIndex: 3 });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('1-based'));
+      assert.ok(res.content[0].text!.includes('1-based'));
     });
 
     it('validation error', async () => {
@@ -398,14 +398,14 @@ describe('Docs tools', () => {
       stubTextFile('abc');
       const res = await callTool(ctx.client, 'insertText', { documentId: 'file-1', text: 'X', index: 99 });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('beyond end of file'));
+      assert.ok(res.content[0].text!.includes('beyond end of file'));
     });
 
     it('insertText rejects tabId on a text file', async () => {
       stubTextFile('abc');
       const res = await callTool(ctx.client, 'insertText', { documentId: 'file-1', text: 'X', index: 0, tabId: 'tab-1' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('tabId is not supported'));
+      assert.ok(res.content[0].text!.includes('tabId is not supported'));
     });
 
     it('deleteRange removes a code-point range', async () => {
@@ -457,7 +457,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Hello World'));
+      assert.ok(res.content[0].text!.includes('Hello World'));
     });
 
     it('reads multi-tab document', async () => {
@@ -482,10 +482,10 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1 ==='));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab2 ==='));
-      assert.ok(res.content[0].text.includes('First tab'));
-      assert.ok(res.content[0].text.includes('Second tab'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1 ==='));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab2 ==='));
+      assert.ok(res.content[0].text!.includes('First tab'));
+      assert.ok(res.content[0].text!.includes('Second tab'));
     });
 
     it('reads specific tab by tabId', async () => {
@@ -510,8 +510,8 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', tabId: 'tab-2' });
       assert.equal(res.isError, false);
-      assert.ok(!res.content[0].text.includes('First tab'));
-      assert.ok(res.content[0].text.includes('Second tab'));
+      assert.ok(!res.content[0].text!.includes('First tab'));
+      assert.ok(res.content[0].text!.includes('Second tab'));
     });
 
     it('reads specific nested tab by tabId', async () => {
@@ -520,10 +520,10 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', tabId: 'tab-1-2' });
       assert.equal(res.isError, false);
-      assert.ok(!res.content[0].text.includes('First tab'));
-      assert.ok(!res.content[0].text.includes('First child'));
-      assert.ok(res.content[0].text.includes('Second child'));
-      assert.ok(!res.content[0].text.includes('Second tab'));
+      assert.ok(!res.content[0].text!.includes('First tab'));
+      assert.ok(!res.content[0].text!.includes('First child'));
+      assert.ok(res.content[0].text!.includes('Second child'));
+      assert.ok(!res.content[0].text!.includes('Second tab'));
     });
     
     it('reads specific nested tab by tabId when the document has only one tab with child tabs', async () => {
@@ -532,10 +532,10 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', tabId: 'tab-1-2' });
       assert.equal(res.isError, false);
-      assert.ok(!res.content[0].text.includes('First tab'));
-      assert.ok(!res.content[0].text.includes('First child'));
-      assert.ok(res.content[0].text.includes('Second child'));
-      assert.ok(!res.content[0].text.includes('Second tab'));
+      assert.ok(!res.content[0].text!.includes('First tab'));
+      assert.ok(!res.content[0].text!.includes('First child'));
+      assert.ok(res.content[0].text!.includes('Second child'));
+      assert.ok(!res.content[0].text!.includes('Second tab'));
     });
 
     it('reads deeply nested grandchild tab by tabId', async () => {
@@ -544,9 +544,9 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', tabId: 'tab-1-2-1' });
       assert.equal(res.isError, false);
-      assert.ok(!res.content[0].text.includes('First tab'));
-      assert.ok(!res.content[0].text.includes('First child'));
-      assert.ok(res.content[0].text.includes('First grandchild'));
+      assert.ok(!res.content[0].text!.includes('First tab'));
+      assert.ok(!res.content[0].text!.includes('First child'));
+      assert.ok(res.content[0].text!.includes('First grandchild'));
     });
 
     it('reads all tabs including nested when no tabId specified', async () => {
@@ -556,16 +556,16 @@ describe('Docs tools', () => {
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
       // Should include all tabs with proper hierarchy
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1 ==='));
-      assert.ok(res.content[0].text.includes('First tab'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.1 ==='));
-      assert.ok(res.content[0].text.includes('First child'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.2 ==='));
-      assert.ok(res.content[0].text.includes('Second child'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.2.1 ==='));
-      assert.ok(res.content[0].text.includes('First grandchild'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab2 ==='));
-      assert.ok(res.content[0].text.includes('Second tab'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1 ==='));
+      assert.ok(res.content[0].text!.includes('First tab'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.1 ==='));
+      assert.ok(res.content[0].text!.includes('First child'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.2 ==='));
+      assert.ok(res.content[0].text!.includes('Second child'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.2.1 ==='));
+      assert.ok(res.content[0].text!.includes('First grandchild'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab2 ==='));
+      assert.ok(res.content[0].text!.includes('Second tab'));
     });
     
     it('reads all tabs including nested when no tabId specified and the document has only one tab with child tabs ', async () => {
@@ -576,14 +576,14 @@ describe('Docs tools', () => {
       assert.equal(res.isError, false);
 
       // Should include all tabs with proper hierarchy
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1 ==='));
-      assert.ok(res.content[0].text.includes('First tab'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.1 ==='));
-      assert.ok(res.content[0].text.includes('First child'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.2 ==='));
-      assert.ok(res.content[0].text.includes('Second child'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.2.1 ==='));
-      assert.ok(res.content[0].text.includes('First grandchild'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1 ==='));
+      assert.ok(res.content[0].text!.includes('First tab'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.1 ==='));
+      assert.ok(res.content[0].text!.includes('First child'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.2 ==='));
+      assert.ok(res.content[0].text!.includes('Second child'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.2.1 ==='));
+      assert.ok(res.content[0].text!.includes('First grandchild'));
     });
 
     it('returns error for unknown tabId', async () => {
@@ -602,7 +602,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', tabId: 'nonexistent' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('not found'));
+      assert.ok(res.content[0].text!.includes('not found'));
     });
 
     it('validation error', async () => {
@@ -638,7 +638,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text!.includes('![Architecture diagram](https://lh3.googleusercontent.com/xyz "objectId=obj-1")'), res.content[0].text);
+      assert.ok(res.content[0].text!.includes('![Architecture diagram](https://lh3.googleusercontent.com/xyz "objectId=obj-1")'), res.content[0].text!);
     });
 
     it('renders inline images as a single-line placeholder (format=text)', async () => {
@@ -692,7 +692,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text!.includes('[image]'), res.content[0].text);
+      assert.ok(res.content[0].text!.includes('[image]'), res.content[0].text!);
     });
 
     it('resolves a multi-tab image against the correct tab inlineObjects map', async () => {
@@ -734,7 +734,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text!.includes('contentUri=https://lh3.googleusercontent.com/tab2'), res.content[0].text);
+      assert.ok(res.content[0].text!.includes('contentUri=https://lh3.googleusercontent.com/tab2'), res.content[0].text!);
     });
 
     it('readGoogleDocPaginated carries inline images (proves format threading)', async () => {
@@ -768,6 +768,73 @@ describe('Docs tools', () => {
       const envelope = JSON.parse(res.content[0].text!);
       assert.ok(envelope.content.includes('![Diagram](https://lh3.googleusercontent.com/xyz "objectId=obj-1")'), envelope.content);
     });
+
+    it('prefers the durable sourceUri over the ephemeral contentUri in markdown', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with sourced image',
+          body: {
+            content: [{
+              paragraph: {
+                elements: [
+                  { inlineObjectElement: { inlineObjectId: 'obj-1' } },
+                  { textRun: { content: '\n' } },
+                ],
+              },
+            }],
+          },
+          inlineObjects: {
+            'obj-1': {
+              inlineObjectProperties: {
+                embeddedObject: {
+                  description: 'Diagram',
+                  imageProperties: {
+                    contentUri: 'https://lh3.googleusercontent.com/ephemeral',
+                    sourceUri: 'https://example.com/durable.png',
+                  },
+                },
+              },
+            },
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('![Diagram](https://example.com/durable.png "objectId=obj-1")'), text);
+      assert.ok(!text.includes('lh3.googleusercontent.com'), 'ephemeral contentUri must not be used when a sourceUri exists');
+    });
+
+    it('percent-encodes spaces and parentheses in the markdown image URL', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with spaced uri',
+          body: {
+            content: [{
+              paragraph: {
+                elements: [
+                  { inlineObjectElement: { inlineObjectId: 'obj-1' } },
+                  { textRun: { content: '\n' } },
+                ],
+              },
+            }],
+          },
+          inlineObjects: {
+            'obj-1': {
+              inlineObjectProperties: {
+                embeddedObject: {
+                  imageProperties: { sourceUri: 'https://example.com/a b(1).png' },
+                },
+              },
+            },
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('![](https://example.com/a%20b%281%29.png "objectId=obj-1")'), text);
+    });
   });
 
   // --- listDocumentTabs ---
@@ -793,7 +860,7 @@ describe('Docs tools', () => {
         documentId: 'doc-1', startIndex: 1, endIndex: 5, bold: true,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('applied text style'));
+      assert.ok(res.content[0].text!.includes('applied text style'));
     });
 
     it('validation error', async () => {
@@ -809,7 +876,7 @@ describe('Docs tools', () => {
         documentId: 'doc-1', startIndex: 1, endIndex: 5, alignment: 'CENTER',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('applied paragraph style'));
+      assert.ok(res.content[0].text!.includes('applied paragraph style'));
     });
 
     it('validation error', async () => {
@@ -842,7 +909,7 @@ describe('Docs tools', () => {
         documentId: 'doc-1', findText: 'Hello', replaceText: 'Hi',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Replaced'));
+      assert.ok(res.content[0].text!.includes('Replaced'));
     });
 
     it('dryRun counts matches without replacing', async () => {
@@ -856,7 +923,7 @@ describe('Docs tools', () => {
         documentId: 'doc-1', findText: 'Hello', replaceText: 'Hi', dryRun: true,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('found 2 occurrence'));
+      assert.ok(res.content[0].text!.includes('found 2 occurrence'));
     });
 
     it('with tabId scopes replacement via tabsCriteria', async () => {
@@ -864,7 +931,7 @@ describe('Docs tools', () => {
         documentId: 'doc-1', findText: 'Hello', replaceText: 'Hi', tabId: 'tab-2',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('tab-2'));
+      assert.ok(res.content[0].text!.includes('tab-2'));
 
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
       const lastCall = calls[calls.length - 1];
@@ -900,7 +967,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'listComments', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Nice!'));
+      assert.ok(res.content[0].text!.includes('Nice!'));
     });
 
     it('validation error', async () => {
@@ -928,7 +995,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'listComments', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('next-page'));
+      assert.ok(res.content[0].text!.includes('next-page'));
     });
 
     it('passes includeDeleted', async () => {
@@ -968,7 +1035,7 @@ describe('Docs tools', () => {
         documentId: 'doc-1', startIndex: 1, endIndex: 5, commentText: 'Great!',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Comment added'));
+      assert.ok(res.content[0].text!.includes('Comment added'));
     });
 
     it('validation: endIndex must be > startIndex', async () => {
@@ -991,7 +1058,7 @@ describe('Docs tools', () => {
         documentId: 'doc-1', commentId: 'c1', replyText: 'Thanks!',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Reply added'));
+      assert.ok(res.content[0].text!.includes('Reply added'));
     });
 
     it('validation error', async () => {
@@ -1009,10 +1076,10 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1 ==='));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab2 ==='));
-      assert.ok(res.content[0].text.includes('First tab'));
-      assert.ok(res.content[0].text.includes('Second tab'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1 ==='));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab2 ==='));
+      assert.ok(res.content[0].text!.includes('First tab'));
+      assert.ok(res.content[0].text!.includes('Second tab'));
     });
 
     it('reads multi-tab document with nested tabs', async () => {
@@ -1022,16 +1089,16 @@ describe('Docs tools', () => {
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
       // Should include all tabs with proper hierarchy
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1 ==='));
-      assert.ok(res.content[0].text.includes('First tab'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.1 ==='));
-      assert.ok(res.content[0].text.includes('First child'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.2 ==='));
-      assert.ok(res.content[0].text.includes('Second child'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.2.1 ==='));
-      assert.ok(res.content[0].text.includes('First grandchild'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab2 ==='));
-      assert.ok(res.content[0].text.includes('Second tab'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1 ==='));
+      assert.ok(res.content[0].text!.includes('First tab'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.1 ==='));
+      assert.ok(res.content[0].text!.includes('First child'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.2 ==='));
+      assert.ok(res.content[0].text!.includes('Second child'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.2.1 ==='));
+      assert.ok(res.content[0].text!.includes('First grandchild'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab2 ==='));
+      assert.ok(res.content[0].text!.includes('Second tab'));
     });
 
     it('reads multi-tab document with nested tabs when the document has only one parent tab with child tabs', async () => {
@@ -1041,14 +1108,14 @@ describe('Docs tools', () => {
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
       // Should include all tabs with proper hierarchy
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1 ==='));
-      assert.ok(res.content[0].text.includes('First tab'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.1 ==='));
-      assert.ok(res.content[0].text.includes('First child'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.2 ==='));
-      assert.ok(res.content[0].text.includes('Second child'));
-      assert.ok(res.content[0].text.includes('=== Tab: Tab1.2.1 ==='));
-      assert.ok(res.content[0].text.includes('First grandchild'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1 ==='));
+      assert.ok(res.content[0].text!.includes('First tab'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.1 ==='));
+      assert.ok(res.content[0].text!.includes('First child'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.2 ==='));
+      assert.ok(res.content[0].text!.includes('Second child'));
+      assert.ok(res.content[0].text!.includes('=== Tab: Tab1.2.1 ==='));
+      assert.ok(res.content[0].text!.includes('First grandchild'));
     });
 
     it('falls back to body for single-tab doc', async () => {
@@ -1056,8 +1123,8 @@ describe('Docs tools', () => {
       ctx.mocks.docs.service.documents.get._resetImpl();
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Hello World'));
-      assert.ok(!res.content[0].text.includes('=== Tab:'));
+      assert.ok(res.content[0].text!.includes('Hello World'));
+      assert.ok(!res.content[0].text!.includes('=== Tab:'));
     });
 
     it('includes formatting when includeFormatting is true', async () => {
@@ -1095,7 +1162,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1', includeFormatting: true });
       assert.equal(res.isError, false);
-      const text = res.content[0].text;
+      const text = res.content[0].text!;
       assert.ok(text.includes('font="Roboto"'), 'should include font name');
       assert.ok(text.includes('size=18pt'), 'should include font size');
       assert.ok(text.includes('style=bold'), 'should include bold style');
@@ -1138,7 +1205,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      const text = res.content[0].text;
+      const text = res.content[0].text!;
       assert.ok(!text.includes('font='), 'should not include font metadata');
       assert.ok(!text.includes('--- Fonts summary ---'), 'should not include fonts summary');
       assert.ok(text.includes('Normal text'), 'should still include text content');
@@ -1193,7 +1260,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1', includeFormatting: true });
       assert.equal(res.isError, false);
-      const text = res.content[0].text;
+      const text = res.content[0].text!;
       assert.ok(text.includes('=== Tab: Tab1 ==='), 'should have tab headers');
       assert.ok(text.includes('=== Tab: Tab2 ==='), 'should have tab headers');
       assert.ok(text.includes('style=italic'), 'should show italic in Tab1');
@@ -1221,8 +1288,8 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Content here'));
-      assert.ok(!res.content[0].text.includes('=== Tab:'));
+      assert.ok(res.content[0].text!.includes('Content here'));
+      assert.ok(!res.content[0].text!.includes('=== Tab:'));
     });
 
     it('extracts person chips', async () => {
@@ -1250,7 +1317,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('@Alice (alice@example.com)'));
+      assert.ok(res.content[0].text!.includes('@Alice (alice@example.com)'));
     });
 
     it('extracts rich links as markdown', async () => {
@@ -1278,7 +1345,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('[Design Doc](https://docs.google.com/doc/123)'));
+      assert.ok(res.content[0].text!.includes('[Design Doc](https://docs.google.com/doc/123)'));
     });
 
     it('extracts inline images with description, uri, and size on one line', async () => {
@@ -1408,6 +1475,130 @@ describe('Docs tools', () => {
       assert.ok(text.includes('alt="Chart \\[v2\\] \\"final\\""'), `alt not escaped: ${text}`);
     });
 
+    it('labels an inline image with its true 1-index span, not the placeholder length', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1',
+          title: 'Doc with indexed image',
+          tabs: [{
+            tabProperties: { title: 'Main' },
+            documentTab: {
+              body: {
+                content: [{
+                  paragraph: {
+                    elements: [
+                      { textRun: { content: 'See ' }, startIndex: 1, endIndex: 5 },
+                      { inlineObjectElement: { inlineObjectId: 'obj-1' }, startIndex: 5, endIndex: 6 },
+                      { textRun: { content: ' here\n' }, startIndex: 6, endIndex: 12 },
+                    ],
+                  },
+                }],
+              },
+              inlineObjects: {
+                'obj-1': {
+                  inlineObjectProperties: {
+                    embeddedObject: {
+                      imageProperties: { contentUri: 'https://lh3.googleusercontent.com/' + 'x'.repeat(120) },
+                    },
+                  },
+                },
+              },
+            },
+          }],
+        },
+      }));
+      const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      const imageLine = text.split('\n').find(l => l.includes('objectId=obj-1'));
+      assert.ok(imageLine, 'image token should be present');
+      // The displayed edit range must be the image's real 1-index span [5-6],
+      // never [5 .. 5+placeholderLength] (which would over-delete following text).
+      assert.ok(imageLine!.startsWith('[5-6] '), `expected [5-6] span, got: ${imageLine}`);
+    });
+
+    it('keeps a multi-line alt-text description on a single placeholder line', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1',
+          title: 'Doc with multi-line alt',
+          tabs: [{
+            tabProperties: { title: 'Main' },
+            documentTab: {
+              body: {
+                content: [{
+                  paragraph: {
+                    elements: [
+                      { inlineObjectElement: { inlineObjectId: 'obj-1' }, startIndex: 1, endIndex: 2 },
+                      { textRun: { content: '\n' }, startIndex: 2, endIndex: 3 },
+                    ],
+                  },
+                }],
+              },
+              inlineObjects: {
+                'obj-1': {
+                  inlineObjectProperties: {
+                    embeddedObject: {
+                      description: 'Line one\nLine two',
+                      imageProperties: { contentUri: 'https://lh3.googleusercontent.com/xyz' },
+                    },
+                  },
+                },
+              },
+            },
+          }],
+        },
+      }));
+      const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      const imageLine = text.split('\n').find(l => l.includes('objectId=obj-1'));
+      assert.ok(imageLine, 'image token should be present on one line');
+      // The newline in the alt text must be collapsed to a space, not leak into output.
+      assert.ok(imageLine!.includes('alt="Line one Line two"'), `alt not single-lined: ${imageLine}`);
+    });
+
+    it('escapes square brackets in image URIs so the placeholder is not truncated', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1',
+          title: 'Doc with bracketed uri',
+          tabs: [{
+            tabProperties: { title: 'Main' },
+            documentTab: {
+              body: {
+                content: [{
+                  paragraph: {
+                    elements: [
+                      { inlineObjectElement: { inlineObjectId: 'obj-1' }, startIndex: 1, endIndex: 2 },
+                      { textRun: { content: '\n' }, startIndex: 2, endIndex: 3 },
+                    ],
+                  },
+                }],
+              },
+              inlineObjects: {
+                'obj-1': {
+                  inlineObjectProperties: {
+                    embeddedObject: {
+                      imageProperties: { sourceUri: 'https://example.com/a]b.png' },
+                    },
+                  },
+                },
+              },
+            },
+          }],
+        },
+      }));
+      const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      const imageLine = text.split('\n').find(l => l.includes('objectId=obj-1'));
+      assert.ok(imageLine, 'image token should be present');
+      // The `]` in the URI must be escaped so it does not close the [image: ...] delimiter early.
+      assert.ok(imageLine!.includes('sourceUri=https://example.com/a\\]b.png'), `uri not escaped: ${imageLine}`);
+      assert.ok(imageLine!.trimEnd().endsWith(']'), 'placeholder should still be closed by a trailing ]');
+    });
+
     it('renders inline images inside table cells without embedded pipes', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({
         data: {
@@ -1485,7 +1676,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('[^1]'));
+      assert.ok(res.content[0].text!.includes('[^1]'));
     });
 
     it('extracts horizontal rules', async () => {
@@ -1509,7 +1700,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('---'));
+      assert.ok(res.content[0].text!.includes('---'));
     });
 
     it('escapes brackets in rich link titles', async () => {
@@ -1536,7 +1727,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      const text = res.content[0].text;
+      const text = res.content[0].text!;
       assert.ok(text.includes('Budget \\[Draft\\]'), 'brackets in title should be escaped');
       assert.ok(text.includes('(https://docs.google.com/doc/456)'), 'URL should be preserved');
     });
@@ -1567,7 +1758,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('[image]'), 'should show placeholder even without inlineObjects map');
+      assert.ok(res.content[0].text!.includes('[image]'), 'should show placeholder even without inlineObjects map');
     });
 
     it('extracts tables as markdown', async () => {
@@ -1606,11 +1797,11 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('| Owner | Role |'));
-      assert.ok(res.content[0].text.includes('| --- | --- |'));
-      assert.ok(res.content[0].text.includes('| Eero | CEO |'));
-      assert.ok(res.content[0].text.includes('Before table'));
-      assert.ok(res.content[0].text.includes('After table'));
+      assert.ok(res.content[0].text!.includes('| Owner | Role |'));
+      assert.ok(res.content[0].text!.includes('| --- | --- |'));
+      assert.ok(res.content[0].text!.includes('| Eero | CEO |'));
+      assert.ok(res.content[0].text!.includes('Before table'));
+      assert.ok(res.content[0].text!.includes('After table'));
     });
 
     it('extracts table of contents content', async () => {
@@ -1640,9 +1831,9 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('1. Introduction'));
-      assert.ok(res.content[0].text.includes('2. Overview'));
-      assert.ok(res.content[0].text.includes('Body text here'));
+      assert.ok(res.content[0].text!.includes('1. Introduction'));
+      assert.ok(res.content[0].text!.includes('2. Overview'));
+      assert.ok(res.content[0].text!.includes('Body text here'));
     });
 
     it('extracts multi-row table with empty cells', async () => {
@@ -1677,8 +1868,8 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('| Field | Value |'));
-      assert.ok(res.content[0].text.includes('| Status |  |'));
+      assert.ok(res.content[0].text!.includes('| Field | Value |'));
+      assert.ok(res.content[0].text!.includes('| Status |  |'));
     });
 
     it('escapes pipe characters in cell text', async () => {
@@ -1711,7 +1902,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      const text = res.content[0].text;
+      const text = res.content[0].text!;
       assert.ok(text.includes('Option A \\| Option B'), 'pipe in cell text should be escaped');
       assert.ok(!text.includes('| Option A | Option B |'), 'unescaped pipe should not produce extra columns');
     });
@@ -1749,7 +1940,7 @@ describe('Docs tools', () => {
       }));
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      const text = res.content[0].text;
+      const text = res.content[0].text!;
       assert.ok(text.includes('Hello World'), 'multi-paragraph cell should join with space');
       assert.ok(!text.includes('HelloWorld'), 'paragraphs should not be concatenated without separator');
     });
@@ -1870,6 +2061,39 @@ describe('Docs tools', () => {
       assert.ok(res.content[0].text!.includes('no fetchable image content'));
     });
 
+    it('surfaces the external sourceUri instead of a misleading no-image error', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with source-only image',
+          body: { content: [] },
+          inlineObjects: {
+            'obj-1': {
+              inlineObjectProperties: {
+                embeddedObject: { imageProperties: { sourceUri: 'https://example.com/a.png' } },
+              },
+            },
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
+      assert.equal(res.isError, true);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('https://example.com/a.png'), text);
+      assert.ok(!text.includes('embedded chart or drawing'), 'should not use the no-image message when a sourceUri exists');
+    });
+
+    it('reports a non-contradictory decimal size when the image exceeds the 40 MB cap', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
+      const oversized = new Uint8Array(42257613).buffer; // ~40.3 MB, just over the 40 MB cap
+      ctx.setAuthRequest(async () => ({ data: oversized, headers: { 'content-type': 'image/png' } }));
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
+      assert.equal(res.isError, true);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('40.3 MB'), `expected decimal size, got: ${text}`);
+      assert.ok(text.includes('limit 40 MB'), text);
+      assert.ok(!text.includes('(40 MB,'), 'must not round to a self-contradictory "40 MB, limit 40 MB"');
+    });
+
     it('validation error when inlineObjectId is missing', async () => {
       const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1' });
       assert.equal(res.isError, true);
@@ -1887,7 +2111,7 @@ describe('Docs tools', () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: longDoc('X'.repeat(120)) }));
       const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', offset: 0, limit: 50 });
       assert.equal(res.isError, false);
-      const r = JSON.parse(res.content[0].text);
+      const r = JSON.parse(res.content[0].text!);
       assert.equal(r.content.length, 50);
       assert.equal(r.outputLength, 120);
       assert.equal(r.documentLength, 120);
@@ -1898,7 +2122,7 @@ describe('Docs tools', () => {
     it('last page reports hasMore false and nextOffset at end', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: longDoc('Y'.repeat(40)) }));
       const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', offset: 0, limit: 50000 });
-      const r = JSON.parse(res.content[0].text);
+      const r = JSON.parse(res.content[0].text!);
       assert.equal(r.content.length, 40);
       assert.equal(r.hasMore, false);
       assert.equal(r.nextOffset, 40);
@@ -1907,7 +2131,7 @@ describe('Docs tools', () => {
     it('offset beyond document returns empty content', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: longDoc('Z'.repeat(30)) }));
       const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', offset: 9999, limit: 50 });
-      const r = JSON.parse(res.content[0].text);
+      const r = JSON.parse(res.content[0].text!);
       assert.equal(r.content, '');
       assert.equal(r.hasMore, false);
       assert.equal(r.nextOffset, 30);
@@ -1916,7 +2140,7 @@ describe('Docs tools', () => {
     it('markdown format includes the title in the first page', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: longDoc('Body text\n') }));
       const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', format: 'markdown', offset: 0, limit: 50000 });
-      const r = JSON.parse(res.content[0].text);
+      const r = JSON.parse(res.content[0].text!);
       assert.ok(r.content.startsWith('# Big Doc'), 'first page should start with the markdown title');
       assert.ok(r.outputLength > r.documentLength, 'outputLength includes the title prefix, documentLength does not');
     });
@@ -1924,7 +2148,7 @@ describe('Docs tools', () => {
     it('reads a specific tab by tabId', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: mockDocs.multiTab() }));
       const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', tabId: 'tab-2', offset: 0, limit: 50000 });
-      const r = JSON.parse(res.content[0].text);
+      const r = JSON.parse(res.content[0].text!);
       assert.ok(r.content.includes('Second tab'));
       assert.ok(!r.content.includes('First tab'));
     });
@@ -1933,7 +2157,7 @@ describe('Docs tools', () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: mockDocs.multiTab() }));
       const res = await callTool(ctx.client, 'readGoogleDocPaginated', { documentId: 'doc-1', tabId: 'nope' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('not found'));
+      assert.ok(res.content[0].text!.includes('not found'));
     });
 
     it('rejects the removed json format', async () => {
@@ -1966,7 +2190,7 @@ describe('Docs tools', () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: indexedDoc() }));
       const res = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: 0, limit: 50000 });
       assert.equal(res.isError, false);
-      const r = JSON.parse(res.content[0].text);
+      const r = JSON.parse(res.content[0].text!);
       assert.ok(r.content.includes('[1-6] Alpha'));
       assert.ok(r.content.includes('[7-12] Bravo'));
       assert.equal(r.hasMore, false);
@@ -1977,7 +2201,7 @@ describe('Docs tools', () => {
     it('snaps the page end to a line boundary so index prefixes are never split', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: indexedDoc() }));
       const page1 = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: 0, limit: 50 });
-      const r1 = JSON.parse(page1.content[0].text);
+      const r1 = JSON.parse(page1.content[0].text!);
       assert.ok(r1.content.endsWith('\n'), 'snapped page must end on a newline');
       assert.ok(r1.content.includes('[1-6] Alpha'), 'the Alpha line must be whole');
       assert.ok(!r1.content.includes('[7-12'), 'the Bravo prefix must not be partially included');
@@ -1985,18 +2209,18 @@ describe('Docs tools', () => {
 
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: indexedDoc() }));
       const page2 = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: r1.nextOffset, limit: 50 });
-      const r2 = JSON.parse(page2.content[0].text);
+      const r2 = JSON.parse(page2.content[0].text!);
       assert.ok(r2.content.startsWith('[7-12] Bravo'), 'next page must start at a clean index prefix');
     });
 
     it('makes forward progress when a single line exceeds the limit', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: oneLongLine() }));
       const page1 = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: 0, limit: 50 });
-      const r1 = JSON.parse(page1.content[0].text);
+      const r1 = JSON.parse(page1.content[0].text!);
 
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: oneLongLine() }));
       const page2 = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: r1.nextOffset, limit: 50 });
-      const r2 = JSON.parse(page2.content[0].text);
+      const r2 = JSON.parse(page2.content[0].text!);
       assert.ok(r2.nextOffset > r1.nextOffset, 'pagination must advance even with no newline in the window');
       assert.ok(r2.content.length > 0, 'page must not be empty');
       assert.equal(r2.hasMore, true);
@@ -2005,7 +2229,7 @@ describe('Docs tools', () => {
     it('offset beyond document returns empty content', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: indexedDoc() }));
       const res = await callTool(ctx.client, 'getGoogleDocContentPaginated', { documentId: 'doc-1', offset: 999999, limit: 50 });
-      const r = JSON.parse(res.content[0].text);
+      const r = JSON.parse(res.content[0].text!);
       assert.equal(r.content, '');
       assert.equal(r.hasMore, false);
       assert.equal(r.nextOffset, r.outputLength);
@@ -2021,7 +2245,7 @@ describe('Docs tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'deleteComment', { documentId: 'doc-1', commentId: 'c1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('deleted'));
+      assert.ok(res.content[0].text!.includes('deleted'));
     });
 
     it('validation error', async () => {
@@ -2055,7 +2279,7 @@ describe('Docs tools', () => {
     it('insertSmartChip happy path', async () => {
       const res = await callTool(ctx.client, 'insertSmartChip', { documentId: 'doc-1', index: 1, chipType: 'person', personEmail: 'user@example.com' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('user@example.com'));
+      assert.ok(res.content[0].text!.includes('user@example.com'));
 
       // Verify the batchUpdate request uses insertPerson (not insertInlineObject)
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
@@ -2091,8 +2315,8 @@ describe('Docs tools', () => {
     it('creates footnote at index without content', async () => {
       const res = await callTool(ctx.client, 'createFootnote', { documentId: 'doc-1', index: 5 });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('fn-123'));
-      assert.ok(res.content[0].text.includes('at index 5'));
+      assert.ok(res.content[0].text!.includes('fn-123'));
+      assert.ok(res.content[0].text!.includes('at index 5'));
 
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
       assert.equal(calls.length, 1);
@@ -2104,7 +2328,7 @@ describe('Docs tools', () => {
     it('creates footnote with content (two batchUpdate calls)', async () => {
       const res = await callTool(ctx.client, 'createFootnote', { documentId: 'doc-1', index: 3, content: 'See reference.' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Content inserted'));
+      assert.ok(res.content[0].text!.includes('Content inserted'));
 
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
       assert.equal(calls.length, 2);
@@ -2119,7 +2343,7 @@ describe('Docs tools', () => {
     it('creates footnote with endOfSegment', async () => {
       const res = await callTool(ctx.client, 'createFootnote', { documentId: 'doc-1', endOfSegment: true });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('end of document'));
+      assert.ok(res.content[0].text!.includes('end of document'));
 
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
       const req = calls[0].args[0].requestBody.requests[0];
@@ -2135,7 +2359,7 @@ describe('Docs tools', () => {
     it('threads tabId into the footnote-reference location (#114)', async () => {
       const res = await callTool(ctx.client, 'createFootnote', { documentId: 'doc-1', index: 5, tabId: 'tab-2' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('in tab tab-2'));
+      assert.ok(res.content[0].text!.includes('in tab tab-2'));
 
       const req = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate')[0].args[0].requestBody.requests[0];
       assert.equal(req.createFootnote.location.index, 5);
@@ -2164,7 +2388,7 @@ describe('Docs tools', () => {
     it('omits tabId from locations when none is given (#114)', async () => {
       const res = await callTool(ctx.client, 'createFootnote', { documentId: 'doc-1', index: 5 });
       assert.equal(res.isError, false);
-      assert.ok(!res.content[0].text.includes('in tab'));
+      assert.ok(!res.content[0].text!.includes('in tab'));
 
       const req = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate')[0].args[0].requestBody.requests[0];
       assert.equal(req.createFootnote.location.tabId, undefined);
@@ -2185,9 +2409,9 @@ describe('Docs tools', () => {
       });
 
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('fn-orphan'));
-      assert.ok(res.content[0].text.includes('failed to insert content'));
-      assert.ok(res.content[0].text.includes('Simulated Docs API failure'));
+      assert.ok(res.content[0].text!.includes('fn-orphan'));
+      assert.ok(res.content[0].text!.includes('failed to insert content'));
+      assert.ok(res.content[0].text!.includes('Simulated Docs API failure'));
 
       const calls = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate');
       assert.equal(calls.length, 2);
@@ -2216,14 +2440,14 @@ describe('Docs tools', () => {
       it('omits tabId from the location by default', async () => {
         const res = await callTool(ctx.client, 'insertTable', { documentId: 'doc-1', rows: 2, columns: 2, index: 1 });
         assert.equal(res.isError, false);
-        assert.ok(!res.content[0].text.includes('in tab'));
+        assert.ok(!res.content[0].text!.includes('in tab'));
         assert.equal(lastRequests()[0].insertTable.location.tabId, undefined);
       });
 
       it('threads tabId into the location', async () => {
         const res = await callTool(ctx.client, 'insertTable', { documentId: 'doc-1', rows: 2, columns: 2, index: 1, tabId: 'tab-2' });
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('in tab tab-2'));
+        assert.ok(res.content[0].text!.includes('in tab tab-2'));
         const req = lastRequests()[0].insertTable;
         assert.equal(req.location.tabId, 'tab-2');
         assert.equal(req.location.index, 1);
@@ -2240,7 +2464,7 @@ describe('Docs tools', () => {
       it('threads tabId into the location', async () => {
         const res = await callTool(ctx.client, 'insertSmartChip', { documentId: 'doc-1', index: 1, chipType: 'person', personEmail: 'a@b.com', tabId: 'tab-2' });
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('in tab tab-2'));
+        assert.ok(res.content[0].text!.includes('in tab tab-2'));
         assert.equal(lastRequests()[0].insertPerson.location.tabId, 'tab-2');
       });
     });
@@ -2264,7 +2488,7 @@ describe('Docs tools', () => {
         ctx.mocks.docs.service.documents.get._resetImpl(); // genuine default mock
         const res = await callTool(ctx.client, 'applyTextStyle', { documentId: 'doc-1', textToFind: 'Hello', bold: true });
         assert.equal(res.isError, false);
-        assert.ok(!res.content[0].text.includes('in tab'));
+        assert.ok(!res.content[0].text!.includes('in tab'));
         assertNoTabGets();
         assert.equal(lastRequests()[0].updateTextStyle.range.tabId, undefined);
       });
@@ -2272,7 +2496,7 @@ describe('Docs tools', () => {
       it('threads tabId into the range (explicit-index mode)', async () => {
         const res = await callTool(ctx.client, 'applyTextStyle', { documentId: 'doc-1', startIndex: 1, endIndex: 5, bold: true, tabId: 'tab-2' });
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('in tab tab-2'));
+        assert.ok(res.content[0].text!.includes('in tab tab-2'));
         assert.equal(lastRequests()[0].updateTextStyle.range.tabId, 'tab-2');
       });
 
@@ -2299,8 +2523,8 @@ describe('Docs tools', () => {
         const before = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length;
         const res = await callTool(ctx.client, 'applyTextStyle', { documentId: 'doc-1', textToFind: 'x', bold: true, tabId: 'missing' });
         assert.equal(res.isError, true);
-        assert.ok(res.content[0].text.includes('Tab with ID "missing" not found'));
-        assert.ok(res.content[0].text.includes('listDocumentTabs'));
+        assert.ok(res.content[0].text!.includes('Tab with ID "missing" not found'));
+        assert.ok(res.content[0].text!.includes('listDocumentTabs'));
         assert.equal(ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length, before);
         ctx.mocks.docs.service.documents.get._resetImpl();
       });
@@ -2311,7 +2535,7 @@ describe('Docs tools', () => {
         ctx.mocks.docs.service.documents.get._resetImpl(); // genuine default mock
         const res = await callTool(ctx.client, 'applyParagraphStyle', { documentId: 'doc-1', textToFind: 'Hello', alignment: 'CENTER' });
         assert.equal(res.isError, false);
-        assert.ok(!res.content[0].text.includes('in tab'));
+        assert.ok(!res.content[0].text!.includes('in tab'));
         assertNoTabGets();
         assert.equal(lastRequests()[0].updateParagraphStyle.range.tabId, undefined);
       });
@@ -2324,7 +2548,7 @@ describe('Docs tools', () => {
         }));
         const res = await callTool(ctx.client, 'applyParagraphStyle', { documentId: 'doc-1', indexWithinParagraph: 2, alignment: 'CENTER', tabId: 'tab-2' });
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('in tab tab-2'));
+        assert.ok(res.content[0].text!.includes('in tab tab-2'));
         assert.equal(lastRequests()[0].updateParagraphStyle.range.tabId, 'tab-2');
         ctx.mocks.docs.service.documents.get._resetImpl();
       });
@@ -2339,7 +2563,7 @@ describe('Docs tools', () => {
         }));
         const res = await callTool(ctx.client, 'applyParagraphStyle', { documentId: 'doc-1', textToFind: 'Find me', alignment: 'CENTER', tabId: 'tab-2' });
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('in tab tab-2'));
+        assert.ok(res.content[0].text!.includes('in tab tab-2'));
 
         // The whole point of the optimization: range + enclosing-paragraph
         // resolution share one includeTabsContent fetch, not two.
@@ -2361,8 +2585,8 @@ describe('Docs tools', () => {
         const before = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length;
         const res = await callTool(ctx.client, 'applyParagraphStyle', { documentId: 'doc-1', textToFind: 'x', alignment: 'CENTER', tabId: 'missing' });
         assert.equal(res.isError, true);
-        assert.ok(res.content[0].text.includes('Tab with ID "missing" not found'));
-        assert.ok(res.content[0].text.includes('listDocumentTabs'));
+        assert.ok(res.content[0].text!.includes('Tab with ID "missing" not found'));
+        assert.ok(res.content[0].text!.includes('listDocumentTabs'));
         assert.equal(ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length, before);
         ctx.mocks.docs.service.documents.get._resetImpl();
       });
@@ -2373,7 +2597,7 @@ describe('Docs tools', () => {
         ctx.mocks.docs.service.documents.get._resetImpl(); // genuine default mock
         const res = await callTool(ctx.client, 'createParagraphBullets', { documentId: 'doc-1', textToFind: 'Hello', bulletPreset: 'BULLET_DISC_CIRCLE_SQUARE' });
         assert.equal(res.isError, false);
-        assert.ok(!res.content[0].text.includes('in tab'));
+        assert.ok(!res.content[0].text!.includes('in tab'));
         assertNoTabGets();
         assert.equal(lastRequests()[0].createParagraphBullets.range.tabId, undefined);
       });
@@ -2381,7 +2605,7 @@ describe('Docs tools', () => {
       it('threads tabId into the range (explicit-index mode)', async () => {
         const res = await callTool(ctx.client, 'createParagraphBullets', { documentId: 'doc-1', startIndex: 1, endIndex: 5, bulletPreset: 'BULLET_DISC_CIRCLE_SQUARE', tabId: 'tab-2' });
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('in tab tab-2'));
+        assert.ok(res.content[0].text!.includes('in tab tab-2'));
         assert.equal(lastRequests()[0].createParagraphBullets.range.tabId, 'tab-2');
       });
 
@@ -2397,7 +2621,7 @@ describe('Docs tools', () => {
         ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: { body: { content: tableContent() } } }));
         const res = await callTool(ctx.client, 'editTableCell', { documentId: 'doc-1', tableStartIndex: 5, rowIndex: 0, columnIndex: 0, textContent: 'Hi' });
         assert.equal(res.isError, false);
-        assert.ok(!res.content[0].text.includes('in tab'));
+        assert.ok(!res.content[0].text!.includes('in tab'));
         const reqs = lastRequests();
         for (const r of reqs) {
           const inner = r.deleteContentRange ?? r.insertText;
@@ -2412,7 +2636,7 @@ describe('Docs tools', () => {
         }));
         const res = await callTool(ctx.client, 'editTableCell', { documentId: 'doc-1', tableStartIndex: 5, rowIndex: 0, columnIndex: 0, textContent: 'Hi', bold: true, alignment: 'CENTER', tabId: 'tab-2' });
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('in tab tab-2'));
+        assert.ok(res.content[0].text!.includes('in tab tab-2'));
 
         const getCalls = ctx.mocks.docs.tracker.getCalls('documents.get');
         assert.equal(getCalls[getCalls.length - 1]?.args?.[0]?.includeTabsContent, true);
@@ -2433,7 +2657,7 @@ describe('Docs tools', () => {
         const before = ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length;
         const res = await callTool(ctx.client, 'editTableCell', { documentId: 'doc-1', tableStartIndex: 5, rowIndex: 0, columnIndex: 0, textContent: 'Hi', tabId: 'missing' });
         assert.equal(res.isError, true);
-        assert.ok(res.content[0].text.includes('Tab with ID "missing" not found'));
+        assert.ok(res.content[0].text!.includes('Tab with ID "missing" not found'));
         assert.equal(ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length, before);
         ctx.mocks.docs.service.documents.get._resetImpl();
       });

--- a/test/integration/drive.test.ts
+++ b/test/integration/drive.test.ts
@@ -24,7 +24,7 @@ describe('Drive tools', () => {
         data: { files: [{ id: 'f1', name: 'Report.pdf', mimeType: 'application/pdf' }] },
       }));
       const res = await callTool(ctx.client, 'search', { query: 'report' });
-      assert.ok(res.content[0].text.includes('Report.pdf'));
+      assert.ok(res.content[0].text!.includes('Report.pdf'));
       assert.equal(res.isError, false);
     });
 
@@ -51,7 +51,7 @@ describe('Drive tools', () => {
       ctx.mocks.drive.service.files.list._setImpl(async () => { throw new Error('API quota exceeded'); });
       const res = await callTool(ctx.client, 'search', { query: 'test' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('API quota exceeded'));
+      assert.ok(res.content[0].text!.includes('API quota exceeded'));
       ctx.mocks.drive.service.files.list._resetImpl();
     });
 
@@ -96,8 +96,8 @@ describe('Drive tools', () => {
         query: "mimeType = 'application/pdf'",
         rawQuery: true,
       });
-      assert.ok(res.content[0].text.includes('created: 2025-06-01T00:00:00Z'));
-      assert.ok(res.content[0].text.includes('modified: 2025-06-15T00:00:00Z'));
+      assert.ok(res.content[0].text!.includes('created: 2025-06-01T00:00:00Z'));
+      assert.ok(res.content[0].text!.includes('modified: 2025-06-15T00:00:00Z'));
       ctx.mocks.drive.service.files.list._resetImpl();
     });
 
@@ -129,7 +129,7 @@ describe('Drive tools', () => {
         return { data: { name: 'Unknown' } };
       });
       const res = await callTool(ctx.client, 'search', { query: 'doc' });
-      assert.ok(res.content[0].text.includes('path: RootFolder/SubFolder'));
+      assert.ok(res.content[0].text!.includes('path: RootFolder/SubFolder'));
       ctx.mocks.drive.service.files.list._resetImpl();
       ctx.mocks.drive.service.files.get._resetImpl();
     });
@@ -164,7 +164,7 @@ describe('Drive tools', () => {
         throw new Error('Not found');
       });
       const res = await callTool(ctx.client, 'search', { query: 'doc' });
-      assert.ok(res.content[0].text.includes('path: bad-folder'));
+      assert.ok(res.content[0].text!.includes('path: bad-folder'));
       ctx.mocks.drive.service.files.list._resetImpl();
       ctx.mocks.drive.service.files.get._resetImpl();
     });
@@ -179,7 +179,7 @@ describe('Drive tools', () => {
         data: { id: 'new-file', name: 'notes.txt' },
       }));
       const res = await callTool(ctx.client, 'createTextFile', { name: 'notes.txt', content: 'hello' });
-      assert.ok(res.content[0].text.includes('notes.txt'));
+      assert.ok(res.content[0].text!.includes('notes.txt'));
       assert.equal(res.isError, false);
     });
 
@@ -216,7 +216,7 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'updateTextFile', { fileId: 'file-1', content: 'x' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('not a text file'));
+      assert.ok(res.content[0].text!.includes('not a text file'));
     });
 
     it('validation error on missing required fields', async () => {
@@ -244,7 +244,7 @@ describe('Drive tools', () => {
       stubTextFile('Hello World');
       const res = await callTool(ctx.client, 'readTextFile', { fileId: 'file-1' });
       assert.equal(res.isError, false);
-      const text = res.content[0].text;
+      const text = res.content[0].text!;
       assert.ok(text.includes('Length: 11 characters'));
       assert.ok(text.includes('Truncated: no'));
       assert.ok(text.endsWith('Hello World'));
@@ -255,7 +255,7 @@ describe('Drive tools', () => {
       const res = await callTool(ctx.client, 'readTextFile', { fileId: 'file-1' });
       assert.equal(res.isError, false);
       // 3 emoji = 3 code points (would be 6 if counting UTF-16 units).
-      assert.ok(res.content[0].text.includes('Length: 3 characters'));
+      assert.ok(res.content[0].text!.includes('Length: 3 characters'));
     });
 
     it('truncates on a code-point boundary without garbling emoji', async () => {
@@ -263,7 +263,7 @@ describe('Drive tools', () => {
       stubTextFile('ab😀cd');
       const res = await callTool(ctx.client, 'readTextFile', { fileId: 'file-1', maxLength: 3 });
       assert.equal(res.isError, false);
-      const text = res.content[0].text;
+      const text = res.content[0].text!;
       assert.ok(text.includes('Length: 5 characters'));
       assert.ok(text.includes('Truncated: yes'));
       assert.ok(text.endsWith('ab😀'));
@@ -274,7 +274,7 @@ describe('Drive tools', () => {
       stubTextFile('irrelevant', 'application/vnd.google-apps.document', 'My Doc');
       const res = await callTool(ctx.client, 'readTextFile', { fileId: 'file-1' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('readGoogleDoc'));
+      assert.ok(res.content[0].text!.includes('readGoogleDoc'));
     });
 
     it('validation error on missing fileId', async () => {
@@ -290,7 +290,7 @@ describe('Drive tools', () => {
         data: { id: 'folder-1', name: 'New Folder' },
       }));
       const res = await callTool(ctx.client, 'createFolder', { name: 'New Folder' });
-      assert.ok(res.content[0].text.includes('New Folder'));
+      assert.ok(res.content[0].text!.includes('New Folder'));
       assert.equal(res.isError, false);
     });
 
@@ -333,8 +333,8 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'listSharedDrives', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Engineering Shared Drive'));
-      assert.ok(res.content[0].text.includes('d1'));
+      assert.ok(res.content[0].text!.includes('Engineering Shared Drive'));
+      assert.ok(res.content[0].text!.includes('d1'));
     });
 
     it('empty result', async () => {
@@ -343,7 +343,7 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'listSharedDrives', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('No shared drives found'));
+      assert.ok(res.content[0].text!.includes('No shared drives found'));
     });
 
     it('pagination token forwarded', async () => {
@@ -352,7 +352,7 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'listSharedDrives', { pageSize: 1 });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('tok2'));
+      assert.ok(res.content[0].text!.includes('tok2'));
     });
   });
 
@@ -361,7 +361,7 @@ describe('Drive tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'deleteItem', { itemId: 'item-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('moved to trash'));
+      assert.ok(res.content[0].text!.includes('moved to trash'));
     });
 
     it('validation error', async () => {
@@ -382,7 +382,7 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'renameItem', { itemId: 'item-1', newName: 'Renamed' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Renamed'));
+      assert.ok(res.content[0].text!.includes('Renamed'));
     });
 
     it('validation error', async () => {
@@ -417,8 +417,8 @@ describe('Drive tools', () => {
 
       const res = await callTool(ctx.client, 'listPermissions', { fileId: 'file-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('[inherited from folder-123]'));
-      assert.ok(res.content[0].text.includes('[direct]'));
+      assert.ok(res.content[0].text!.includes('[inherited from folder-123]'));
+      assert.ok(res.content[0].text!.includes('[direct]'));
 
       const listCalls = ctx.mocks.drive.tracker.getCalls('permissions.list');
       assert.ok(listCalls.length >= 1);
@@ -469,7 +469,7 @@ describe('Drive tools', () => {
         fileId: 'file-1', type: 'user', role: 'reader',
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.toLowerCase().includes('emailaddress'));
+      assert.ok(res.content[0].text!.toLowerCase().includes('emailaddress'));
       assert.equal(ctx.mocks.drive.tracker.getCalls('permissions.create').length, 0);
     });
 
@@ -478,7 +478,7 @@ describe('Drive tools', () => {
         fileId: 'file-1', type: 'domain', role: 'reader',
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.toLowerCase().includes('domain'));
+      assert.ok(res.content[0].text!.toLowerCase().includes('domain'));
       assert.equal(ctx.mocks.drive.tracker.getCalls('permissions.create').length, 0);
     });
 
@@ -535,7 +535,7 @@ describe('Drive tools', () => {
       });
 
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Updated existing permission'));
+      assert.ok(res.content[0].text!.includes('Updated existing permission'));
 
       const createCalls = ctx.mocks.drive.tracker.getCalls('permissions.create');
       const updateCalls = ctx.mocks.drive.tracker.getCalls('permissions.update');
@@ -577,7 +577,7 @@ describe('Drive tools', () => {
       });
 
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('No changes needed'));
+      assert.ok(res.content[0].text!.includes('No changes needed'));
     });
 
     it('addPermission forwards emailMessage to permissions.create', async () => {
@@ -621,7 +621,7 @@ describe('Drive tools', () => {
     it('authGetStatus returns status payload', async () => {
       const res = await callTool(ctx.client, 'authGetStatus', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Auth status'));
+      assert.ok(res.content[0].text!.includes('Auth status'));
     });
 
     it('authGetStatus reports the effective identity and oauth mode', async () => {
@@ -632,7 +632,7 @@ describe('Drive tools', () => {
       try {
         const res = await callTool(ctx.client, 'authGetStatus', {});
         assert.equal(res.isError, false);
-        const text = res.content[0].text;
+        const text = res.content[0].text!;
         assert.ok(text.includes('ada@example.com'), 'effective identity email is surfaced');
         assert.ok(/"authMode":\s*"oauth"/.test(text), 'active auth mode is oauth');
       } finally {
@@ -651,7 +651,7 @@ describe('Drive tools', () => {
       });
       try {
         const res = await callTool(ctx.client, 'authGetStatus', {});
-        const text = res.content[0].text;
+        const text = res.content[0].text!;
         assert.ok(/"authMode":\s*"service_account"/.test(text), 'active auth mode is service_account');
         assert.ok(text.includes('IGNORED'), 'warns that the local token file is ignored');
         assert.ok(text.includes('GOOGLE_APPLICATION_CREDENTIALS'), 'names the overriding env var');
@@ -675,7 +675,7 @@ describe('Drive tools', () => {
       ctx.mocks.drive.service.about.get._setImpl(async () => { throw new Error('No refresh token is set.'); });
       try {
         const res = await callTool(ctx.client, 'authGetStatus', {});
-        const text = res.content[0].text;
+        const text = res.content[0].text!;
         assert.ok(/"authMode":\s*"oauth"/.test(text), 'active auth mode is oauth');
         assert.ok(/Auth status \(needs_reauth\)/.test(text), 'status is needs_reauth, not identity_error');
       } finally {
@@ -695,7 +695,7 @@ describe('Drive tools', () => {
       ctx.mocks.drive.service.about.get._setImpl(async () => { throw new Error('Insufficient Permission'); });
       try {
         const res = await callTool(ctx.client, 'authGetStatus', {});
-        const text = res.content[0].text;
+        const text = res.content[0].text!;
         assert.ok(/Auth status \(identity_error\)/.test(text), 'status is identity_error');
         assert.ok(text.includes('Insufficient Permission'), 'includes the underlying error message');
       } finally {
@@ -707,13 +707,13 @@ describe('Drive tools', () => {
     it('authListScopes returns scopes payload', async () => {
       const res = await callTool(ctx.client, 'authListScopes', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('requestedScopes'));
+      assert.ok(res.content[0].text!.includes('requestedScopes'));
     });
 
     it('authTestFileAccess works without fileId', async () => {
       const res = await callTool(ctx.client, 'authTestFileAccess', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Auth access check OK'));
+      assert.ok(res.content[0].text!.includes('Auth access check OK'));
     });
 
     it('authTestFileAccess with specific fileId', async () => {
@@ -722,7 +722,7 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'authTestFileAccess', { fileId: 'file-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('"mode":"file"') || res.content[0].text.includes('"mode": "file"'));
+      assert.ok(res.content[0].text!.includes('"mode":"file"') || res.content[0].text!.includes('"mode": "file"'));
     });
 
   });
@@ -732,13 +732,13 @@ describe('Drive tools', () => {
     it('getRevisions happy path', async () => {
       const res = await callTool(ctx.client, 'getRevisions', { fileId: 'file-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Revisions for file file-1'));
+      assert.ok(res.content[0].text!.includes('Revisions for file file-1'));
     });
 
     it('restoreRevision requires confirmation', async () => {
       const res = await callTool(ctx.client, 'restoreRevision', { fileId: 'file-1', revisionId: '1' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('confirm=true'));
+      assert.ok(res.content[0].text!.includes('confirm=true'));
     });
 
     it('restoreRevision happy path (workspace file) includes formatting warning', async () => {
@@ -756,8 +756,8 @@ describe('Drive tools', () => {
 
       const res = await callTool(ctx.client, 'restoreRevision', { fileId: 'file-1', revisionId: '1', confirm: true });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Restored file file-1'));
-      assert.ok(res.content[0].text.includes('restored via export/import'), 'Should include workspace formatting warning');
+      assert.ok(res.content[0].text!.includes('Restored file file-1'));
+      assert.ok(res.content[0].text!.includes('restored via export/import'), 'Should include workspace formatting warning');
 
       // Should use revisions.get for exportLinks, not files.export
       const revGetCalls = ctx.mocks.drive.tracker.getCalls('revisions.get');
@@ -771,8 +771,8 @@ describe('Drive tools', () => {
 
       const res = await callTool(ctx.client, 'restoreRevision', { fileId: 'file-1', revisionId: '2', confirm: true });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Restored file file-1'));
-      assert.ok(!res.content[0].text.includes('export/import'), 'Should NOT include workspace warning for binary files');
+      assert.ok(res.content[0].text!.includes('Restored file file-1'));
+      assert.ok(!res.content[0].text!.includes('export/import'), 'Should NOT include workspace warning for binary files');
 
       const revGetCalls = ctx.mocks.drive.tracker.getCalls('revisions.get');
       assert.ok(revGetCalls.length >= 1, 'Should use revisions.get for binary download');
@@ -809,8 +809,8 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'createShortcut', { targetFileId: 'target-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Shortcut created successfully'));
-      assert.ok(res.content[0].text.includes('Report.pdf'));
+      assert.ok(res.content[0].text!.includes('Shortcut created successfully'));
+      assert.ok(res.content[0].text!.includes('Report.pdf'));
 
       const createCalls = ctx.mocks.drive.tracker.getCalls('files.create');
       assert.ok(createCalls.length >= 1);
@@ -828,7 +828,7 @@ describe('Drive tools', () => {
         data: { id: 'shortcut-1', name: 'My Link', webViewLink: 'https://drive.google.com/shortcut-1' },
       }));
       const res = await callTool(ctx.client, 'createShortcut', { targetFileId: 'target-1', shortcutName: 'My Link' });
-      assert.ok(res.content[0].text.includes('My Link'));
+      assert.ok(res.content[0].text!.includes('My Link'));
 
       const createCalls = ctx.mocks.drive.tracker.getCalls('files.create');
       const createArgs = createCalls[createCalls.length - 1].args[0];
@@ -849,8 +849,8 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'lockFile', { fileId: 'file-1', reason: 'Final version' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('File locked successfully'));
-      assert.ok(res.content[0].text.includes('Final version'));
+      assert.ok(res.content[0].text!.includes('File locked successfully'));
+      assert.ok(res.content[0].text!.includes('Final version'));
 
       const updateCalls = ctx.mocks.drive.tracker.getCalls('files.update');
       assert.ok(updateCalls.length >= 1);
@@ -864,7 +864,7 @@ describe('Drive tools', () => {
         data: { id: 'file-1', name: 'Report.docx', contentRestrictions: [{ readOnly: true, reason: 'Locked' }] },
       }));
       const res = await callTool(ctx.client, 'lockFile', { fileId: 'file-1' });
-      assert.ok(res.content[0].text.includes('already locked'));
+      assert.ok(res.content[0].text!.includes('already locked'));
     });
 
     it('uses default reason when none provided', async () => {
@@ -872,7 +872,7 @@ describe('Drive tools', () => {
         data: { id: 'file-1', name: 'Report.docx', contentRestrictions: [] },
       }));
       const res = await callTool(ctx.client, 'lockFile', { fileId: 'file-1' });
-      assert.ok(res.content[0].text.includes('Locked via MCP'));
+      assert.ok(res.content[0].text!.includes('Locked via MCP'));
     });
 
     it('validation error on missing fileId', async () => {
@@ -889,7 +889,7 @@ describe('Drive tools', () => {
       }));
       const res = await callTool(ctx.client, 'unlockFile', { fileId: 'file-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('File unlocked successfully'));
+      assert.ok(res.content[0].text!.includes('File unlocked successfully'));
 
       const updateCalls = ctx.mocks.drive.tracker.getCalls('files.update');
       assert.ok(updateCalls.length >= 1);
@@ -902,7 +902,7 @@ describe('Drive tools', () => {
         data: { id: 'file-1', name: 'Report.docx', contentRestrictions: [] },
       }));
       const res = await callTool(ctx.client, 'unlockFile', { fileId: 'file-1' });
-      assert.ok(res.content[0].text.includes('not locked'));
+      assert.ok(res.content[0].text!.includes('not locked'));
     });
 
     it('validation error on missing fileId', async () => {
@@ -924,7 +924,7 @@ describe('Drive tools', () => {
       ctx.mocks.drive.service.files.copy._setImpl(async () => ({ data: { id: 'd1', name: 'X (Doc)' } }));
       const res = await callTool(ctx.client, 'bulkConvertFolderPdfs', { folderId: 'folder-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Success=1'));
+      assert.ok(res.content[0].text!.includes('Success=1'));
     });
 
     it('uploadPdfWithSplit performs real split uploads', async () => {
@@ -952,9 +952,9 @@ describe('Drive tools', () => {
         });
 
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('Uploaded split PDF into 2 part(s)'));
-        assert.ok(res.content[0].text.includes('invoice-part-1.pdf'));
-        assert.ok(res.content[0].text.includes('invoice-part-2.pdf'));
+        assert.ok(res.content[0].text!.includes('Uploaded split PDF into 2 part(s)'));
+        assert.ok(res.content[0].text!.includes('invoice-part-1.pdf'));
+        assert.ok(res.content[0].text!.includes('invoice-part-2.pdf'));
 
         const createCalls = ctx.mocks.drive.tracker.getCalls('files.create');
         assert.equal(createCalls.length, 2);

--- a/test/integration/manage-accounts.test.ts
+++ b/test/integration/manage-accounts.test.ts
@@ -21,7 +21,7 @@ describe('manage_accounts (test-mode harness)', () => {
   it("list returns the synthetic 'test' account", async () => {
     const result = await callTool(ctx.client, 'manage_accounts', { action: 'list' });
     assert.notEqual(result.isError, true, `list errored: ${JSON.stringify(result)}`);
-    const text = result.content[0].text;
+    const text = result.content[0].text!;
     const payload = JSON.parse(text);
     assert.equal(payload.mode, 'test');
     assert.equal(payload.defaultAccount, 'test');
@@ -41,7 +41,7 @@ describe('manage_accounts (test-mode harness)', () => {
     });
     assert.equal(result.isError, true);
     assert.match(
-      result.content[0].text,
+      result.content[0].text!,
       /only supported in local-OAuth mode.*test/,
     );
   });
@@ -64,7 +64,7 @@ describe('manage_accounts (test-mode harness)', () => {
       account_id: 'test',
     });
     assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /only supported in local-OAuth mode/);
+    assert.match(result.content[0].text!, /only supported in local-OAuth mode/);
   });
 
   it('set_default refuses in non-local-oauth modes', async () => {
@@ -73,7 +73,7 @@ describe('manage_accounts (test-mode harness)', () => {
       account_id: 'test',
     });
     assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /only supported in local-OAuth mode/);
+    assert.match(result.content[0].text!, /only supported in local-OAuth mode/);
   });
 
   it('missing action returns a zod validation error', async () => {
@@ -115,8 +115,8 @@ describe('per-tool account parameter', () => {
       account: 'nope',
     });
     assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /Unknown account/);
-    assert.match(result.content[0].text, /manage_accounts list/);
+    assert.match(result.content[0].text!, /Unknown account/);
+    assert.match(result.content[0].text!, /manage_accounts list/);
   });
 
   it('strips account from args before the handler sees them', async () => {
@@ -192,7 +192,7 @@ describe('manage_accounts with zero accounts', () => {
   it('list returns an empty list instead of a lockout error', async () => {
     const result = await callTool(ctx.client, 'manage_accounts', { action: 'list' });
     assert.notEqual(result.isError, true, `list errored: ${JSON.stringify(result)}`);
-    const payload = JSON.parse(result.content[0].text);
+    const payload = JSON.parse(result.content[0].text!);
     assert.equal(payload.defaultAccount, null);
     assert.deepEqual(payload.accounts, []);
   });
@@ -237,8 +237,8 @@ describe('manage_accounts set_default accepts JSON null (finding 13)', () => {
       account_id: null,
     });
     assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /only supported in local-OAuth mode/);
-    assert.doesNotMatch(result.content[0].text, /Expected string|Invalid|received null/);
+    assert.match(result.content[0].text!, /only supported in local-OAuth mode/);
+    assert.doesNotMatch(result.content[0].text!, /Expected string|Invalid|received null/);
   });
 });
 

--- a/test/integration/multi-account-dispatch.test.ts
+++ b/test/integration/multi-account-dispatch.test.ts
@@ -85,7 +85,7 @@ describe('Multi-account dispatch routing', () => {
   it('manage_accounts list reports all three synthetic accounts', async () => {
     const result = await callTool(ctx.client, 'manage_accounts', { action: 'list' });
     assert.notEqual(result.isError, true);
-    const payload = JSON.parse(result.content[0].text);
+    const payload = JSON.parse(result.content[0].text!);
     const aliases = (payload.accounts as Array<{ alias: string }>).map((a) => a.alias).sort();
     assert.deepEqual(aliases, ['alpha', 'beta', 'test']);
   });
@@ -110,7 +110,7 @@ describe('Multi-account dispatch routing', () => {
       account: 'nonexistent',
     });
     assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /Unknown account/);
+    assert.match(result.content[0].text!, /Unknown account/);
     // No drive service should have been instantiated for this rejected call.
     const markers = authCalls.map((c) => c.marker).filter((m) => m !== undefined);
     assert.ok(
@@ -127,7 +127,7 @@ describe('Multi-account dispatch routing', () => {
       account: ['alpha', 'beta'] as unknown as string,
     });
     assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /single account alias|one call per account/);
+    assert.match(result.content[0].text!, /single account alias|one call per account/);
     // Threw before dispatch — no drive service built for either account.
     const markers = authCalls.map((c) => c.marker).filter((m) => m !== undefined);
     assert.ok(
@@ -142,6 +142,6 @@ describe('Multi-account dispatch routing', () => {
       account: 42 as unknown as string,
     });
     assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /single account alias|one call per account/);
+    assert.match(result.content[0].text!, /single account alias|one call per account/);
   });
 });

--- a/test/integration/sheets.test.ts
+++ b/test/integration/sheets.test.ts
@@ -34,7 +34,7 @@ describe('Sheets tools', () => {
         name: 'My Sheet', data: [['A', 'B'], ['1', '2']],
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('My Sheet'));
+      assert.ok(res.content[0].text!.includes('My Sheet'));
     });
 
     it('validation error', async () => {
@@ -50,7 +50,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:B2', data: [['a', 'b']],
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Updated'));
+      assert.ok(res.content[0].text!.includes('Updated'));
     });
 
     it('validation error', async () => {
@@ -69,7 +69,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:B2',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Alice'));
+      assert.ok(res.content[0].text!.includes('Alice'));
     });
 
     it('validation error', async () => {
@@ -87,7 +87,7 @@ describe('Sheets tools', () => {
         horizontalAlignment: 'CENTER',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Formatted'));
+      assert.ok(res.content[0].text!.includes('Formatted'));
     });
 
     it('validation error', async () => {
@@ -104,7 +104,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:B2', bold: true,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('text formatting'));
+      assert.ok(res.content[0].text!.includes('text formatting'));
     });
 
     it('validation error', async () => {
@@ -121,7 +121,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:B2', pattern: '#,##0.00',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('number formatting'));
+      assert.ok(res.content[0].text!.includes('number formatting'));
     });
 
     it('validation error', async () => {
@@ -138,7 +138,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:B2', style: 'SOLID',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('borders'));
+      assert.ok(res.content[0].text!.includes('borders'));
     });
 
     it('validation error', async () => {
@@ -155,7 +155,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:C3', mergeType: 'MERGE_ALL',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Merged'));
+      assert.ok(res.content[0].text!.includes('Merged'));
     });
 
     it('validation error', async () => {
@@ -175,7 +175,7 @@ describe('Sheets tools', () => {
         format: { backgroundColor: { red: 1, green: 0, blue: 0 } },
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('conditional formatting'));
+      assert.ok(res.content[0].text!.includes('conditional formatting'));
     });
 
     it('validation error', async () => {
@@ -190,7 +190,7 @@ describe('Sheets tools', () => {
       setupSheetsMock();
       const res = await callTool(ctx.client, 'getSpreadsheetInfo', { spreadsheetId: 'sheet-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Test Sheet'));
+      assert.ok(res.content[0].text!.includes('Test Sheet'));
     });
 
     it('validation error', async () => {
@@ -206,7 +206,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'A1', values: [['x', 'y']],
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('appended'));
+      assert.ok(res.content[0].text!.includes('appended'));
     });
 
     it('validation error', async () => {
@@ -222,7 +222,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetTitle: 'Sheet2',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Sheet2'));
+      assert.ok(res.content[0].text!.includes('Sheet2'));
     });
 
     it('validation error', async () => {
@@ -241,7 +241,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', title: 'AliasSheet',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('AliasSheet'));
+      assert.ok(res.content[0].text!.includes('AliasSheet'));
     });
 
     it('validation error', async () => {
@@ -256,19 +256,19 @@ describe('Sheets tools', () => {
       setupSheetsMock();
       const res = await callTool(ctx.client, 'listSheets', { spreadsheetId: 'sheet-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Sheet1'));
+      assert.ok(res.content[0].text!.includes('Sheet1'));
     });
 
     it('renameSheet happy path', async () => {
       const res = await callTool(ctx.client, 'renameSheet', { spreadsheetId: 'sheet-1', sheetId: 0, newTitle: 'Renamed' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Renamed'));
+      assert.ok(res.content[0].text!.includes('Renamed'));
     });
 
     it('deleteSheet happy path', async () => {
       const res = await callTool(ctx.client, 'deleteSheet', { spreadsheetId: 'sheet-1', sheetId: 0 });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Deleted sheet'));
+      assert.ok(res.content[0].text!.includes('Deleted sheet'));
     });
 
     it('deleteSheet validation error', async () => {
@@ -285,7 +285,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:A10', conditionType: 'ONE_OF_LIST', values: ['A', 'B'],
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Added data validation'));
+      assert.ok(res.content[0].text!.includes('Added data validation'));
     });
 
     it('addDataValidation ONE_OF_RANGE happy path prepends "="', async () => {
@@ -294,7 +294,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:A10', conditionType: 'ONE_OF_RANGE', values: ['Reference!A2:A50'],
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Added data validation (ONE_OF_RANGE)'));
+      assert.ok(res.content[0].text!.includes('Added data validation (ONE_OF_RANGE)'));
       const calls = ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate');
       const rule = calls[0].args[0].requestBody.requests[0].setDataValidation.rule;
       assert.equal(rule.condition.type, 'ONE_OF_RANGE');
@@ -332,7 +332,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', range: 'Sheet1!A1:B10', description: 'Lock critical',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Protected range'));
+      assert.ok(res.content[0].text!.includes('Protected range'));
     });
 
     it('addNamedRange happy path', async () => {
@@ -341,7 +341,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', name: 'InputRange', range: 'Sheet1!A1:B10',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Added named range'));
+      assert.ok(res.content[0].text!.includes('Added named range'));
     });
   });
 
@@ -352,7 +352,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, startColumn: 0, endColumn: 3, pixelSize: 120,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Set column width'));
+      assert.ok(res.content[0].text!.includes('Set column width'));
       const req = ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate')[0].args[0].requestBody.requests[0];
       assert.deepEqual(req.updateDimensionProperties.range, { sheetId: 0, dimension: 'COLUMNS', startIndex: 0, endIndex: 3 });
       assert.deepEqual(req.updateDimensionProperties.properties, { pixelSize: 120 });
@@ -371,7 +371,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, startColumn: 5, endColumn: 2, pixelSize: 120,
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('startColumn must be less than endColumn'));
+      assert.ok(res.content[0].text!.includes('startColumn must be less than endColumn'));
       assert.equal(ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate').length, 0);
     });
 
@@ -385,7 +385,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, startRow: 0, endRow: 5, pixelSize: 30,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Set row height'));
+      assert.ok(res.content[0].text!.includes('Set row height'));
       const req = ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate')[0].args[0].requestBody.requests[0];
       assert.deepEqual(req.updateDimensionProperties.range, { sheetId: 0, dimension: 'ROWS', startIndex: 0, endIndex: 5 });
       assert.deepEqual(req.updateDimensionProperties.properties, { pixelSize: 30 });
@@ -404,7 +404,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, startRow: 5, endRow: 2, pixelSize: 30,
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('startRow must be less than endRow'));
+      assert.ok(res.content[0].text!.includes('startRow must be less than endRow'));
       assert.equal(ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate').length, 0);
     });
 
@@ -418,7 +418,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, startColumn: 0, endColumn: 3,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Auto-resized columns'));
+      assert.ok(res.content[0].text!.includes('Auto-resized columns'));
       const req = ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate')[0].args[0].requestBody.requests[0];
       assert.deepEqual(req.autoResizeDimensions.dimensions, { sheetId: 0, dimension: 'COLUMNS', startIndex: 0, endIndex: 3 });
     });
@@ -433,7 +433,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, startRow: 0, endRow: 5,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Auto-resized rows'));
+      assert.ok(res.content[0].text!.includes('Auto-resized rows'));
       const req = ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate')[0].args[0].requestBody.requests[0];
       assert.deepEqual(req.autoResizeDimensions.dimensions, { sheetId: 0, dimension: 'ROWS', startIndex: 0, endIndex: 5 });
     });
@@ -448,7 +448,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, dimension: 'COLUMNS', startIndex: 2, endIndex: 4,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Hid columns'));
+      assert.ok(res.content[0].text!.includes('Hid columns'));
       const req = ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate')[0].args[0].requestBody.requests[0];
       assert.deepEqual(req.updateDimensionProperties.range, { sheetId: 0, dimension: 'COLUMNS', startIndex: 2, endIndex: 4 });
       assert.deepEqual(req.updateDimensionProperties.properties, { hiddenByUser: true });
@@ -460,7 +460,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, dimension: 'ROWS', startIndex: 2, endIndex: 4,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Showed rows'));
+      assert.ok(res.content[0].text!.includes('Showed rows'));
       const req = ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate')[0].args[0].requestBody.requests[0];
       assert.deepEqual(req.updateDimensionProperties.range, { sheetId: 0, dimension: 'ROWS', startIndex: 2, endIndex: 4 });
       assert.deepEqual(req.updateDimensionProperties.properties, { hiddenByUser: false });
@@ -484,7 +484,7 @@ describe('Sheets tools', () => {
         spreadsheetId: 'sheet-1', sheetId: 0, dimension: 'COLUMNS', startIndex: 4, endIndex: 2,
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('startIndex must be less than endIndex'));
+      assert.ok(res.content[0].text!.includes('startIndex must be less than endIndex'));
       assert.equal(ctx.mocks.sheets.tracker.getCalls('spreadsheets.batchUpdate').length, 0);
     });
   });
@@ -497,7 +497,7 @@ describe('Sheets tools', () => {
       }));
       const res = await callTool(ctx.client, 'listGoogleSheets', {});
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Budget'));
+      assert.ok(res.content[0].text!.includes('Budget'));
     });
   });
 
@@ -509,7 +509,7 @@ describe('Sheets tools', () => {
       }));
       const res = await callTool(ctx.client, 'copyFile', { fileId: 'file-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('copied'));
+      assert.ok(res.content[0].text!.includes('copied'));
     });
 
     it('validation error', async () => {

--- a/test/integration/slides.test.ts
+++ b/test/integration/slides.test.ts
@@ -30,7 +30,7 @@ describe('Slides tools', () => {
         slides: [{ title: 'Slide 1', content: 'Content 1' }],
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('My Presentation'));
+      assert.ok(res.content[0].text!.includes('My Presentation'));
     });
 
     it('validation error', async () => {
@@ -47,7 +47,7 @@ describe('Slides tools', () => {
         slides: [{ title: 'Updated Title', content: 'Updated Content' }],
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Updated'));
+      assert.ok(res.content[0].text!.includes('Updated'));
     });
 
     it('validation error', async () => {
@@ -61,7 +61,7 @@ describe('Slides tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'getGoogleDocContent', { documentId: 'doc-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Document content'));
+      assert.ok(res.content[0].text!.includes('Document content'));
     });
 
     it('validation error', async () => {
@@ -75,7 +75,7 @@ describe('Slides tools', () => {
     it('happy path', async () => {
       const res = await callTool(ctx.client, 'getGoogleSlidesContent', { presentationId: 'pres-1' });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Presentation content'));
+      assert.ok(res.content[0].text!.includes('Presentation content'));
     });
 
     it('validation error', async () => {
@@ -91,7 +91,7 @@ describe('Slides tools', () => {
         presentationId: 'pres-1', objectId: 'title-1', bold: true,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('formatting'));
+      assert.ok(res.content[0].text!.includes('formatting'));
     });
 
     it('error when no formatting specified', async () => {
@@ -99,7 +99,7 @@ describe('Slides tools', () => {
         presentationId: 'pres-1', objectId: 'title-1',
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('No formatting'));
+      assert.ok(res.content[0].text!.includes('No formatting'));
     });
 
     it('validation error', async () => {
@@ -115,7 +115,7 @@ describe('Slides tools', () => {
         presentationId: 'pres-1', objectId: 'title-1', alignment: 'CENTER',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('paragraph formatting'));
+      assert.ok(res.content[0].text!.includes('paragraph formatting'));
     });
 
     it('error when no formatting specified', async () => {
@@ -139,7 +139,7 @@ describe('Slides tools', () => {
         backgroundColor: { red: 1, green: 0, blue: 0 },
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('styling'));
+      assert.ok(res.content[0].text!.includes('styling'));
     });
 
     it('error when no styling specified', async () => {
@@ -164,7 +164,7 @@ describe('Slides tools', () => {
         backgroundColor: { red: 0, green: 0, blue: 1 },
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('background'));
+      assert.ok(res.content[0].text!.includes('background'));
     });
 
     it('validation error', async () => {
@@ -181,7 +181,7 @@ describe('Slides tools', () => {
         text: 'Hello', x: 100, y: 100, width: 300, height: 50,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('text box'));
+      assert.ok(res.content[0].text!.includes('text box'));
     });
 
     it('validation error', async () => {
@@ -198,7 +198,7 @@ describe('Slides tools', () => {
         shapeType: 'RECTANGLE', x: 100, y: 100, width: 200, height: 200,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('RECTANGLE'));
+      assert.ok(res.content[0].text!.includes('RECTANGLE'));
     });
 
     it('validation error', async () => {
@@ -226,7 +226,7 @@ describe('Slides tools', () => {
         presentationId: 'pres-1', slideObjectId: 'slide-1',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Duplicated'));
+      assert.ok(res.content[0].text!.includes('Duplicated'));
     });
 
     it('reorderSlides happy path', async () => {
@@ -241,7 +241,7 @@ describe('Slides tools', () => {
         presentationId: 'pres-1', containsText: 'Old', replaceText: 'New',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Replaced'));
+      assert.ok(res.content[0].text!.includes('Replaced'));
     });
   });
 
@@ -252,7 +252,7 @@ describe('Slides tools', () => {
         presentationId: 'pres-1', slideObjectId: 'slide-1', mimeType: 'PNG', size: 'LARGE',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('thumbnail URL'));
+      assert.ok(res.content[0].text!.includes('thumbnail URL'));
     });
 
     it('validation error', async () => {
@@ -268,7 +268,7 @@ describe('Slides tools', () => {
         presentationId: 'pres-1', slideIndex: 0,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Speaker notes text'));
+      assert.ok(res.content[0].text!.includes('Speaker notes text'));
     });
 
     it('validation error', async () => {
@@ -284,7 +284,7 @@ describe('Slides tools', () => {
         presentationId: 'pres-1', slideIndex: 0, notes: 'New notes',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('updated speaker notes'));
+      assert.ok(res.content[0].text!.includes('updated speaker notes'));
     });
 
     it('update slides with existing notes', async () => {

--- a/test/integration/tables-media.test.ts
+++ b/test/integration/tables-media.test.ts
@@ -19,7 +19,7 @@ describe('Tables & Media tools', () => {
         documentId: 'doc-1', rows: 3, columns: 4, index: 1,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('3x4'));
+      assert.ok(res.content[0].text!.includes('3x4'));
     });
 
     it('validation error', async () => {
@@ -56,7 +56,7 @@ describe('Tables & Media tools', () => {
         textContent: 'new value',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('edited cell'));
+      assert.ok(res.content[0].text!.includes('edited cell'));
     });
 
     it('validation error', async () => {
@@ -72,7 +72,7 @@ describe('Tables & Media tools', () => {
         documentId: 'doc-1', imageUrl: 'https://example.com/image.png', index: 1,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('inserted image'));
+      assert.ok(res.content[0].text!.includes('inserted image'));
     });
 
     it('validation error', async () => {

--- a/test/integration/upload-download.test.ts
+++ b/test/integration/upload-download.test.ts
@@ -24,7 +24,7 @@ describe('Upload & Download tools', () => {
     it('error when file does not exist', async () => {
       const res = await callTool(ctx.client, 'uploadFile', { localPath: '/nonexistent/file.txt' });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('not found'));
+      assert.ok(res.content[0].text!.includes('not found'));
     });
 
     it('validation error when both localPath and contentBase64 are provided', async () => {
@@ -33,7 +33,7 @@ describe('Upload & Download tools', () => {
         contentBase64: 'aGVsbG8=',
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('exactly one'));
+      assert.ok(res.content[0].text!.includes('exactly one'));
     });
 
     it('creates a new file from contentBase64', async () => {
@@ -42,7 +42,7 @@ describe('Upload & Download tools', () => {
         name: 'hello.png',
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Uploaded:'));
+      assert.ok(res.content[0].text!.includes('Uploaded:'));
       const creates = ctx.mocks.drive.tracker.getCalls('files.create');
       assert.equal(creates.length, 1);
       assert.equal(creates[0].args[0].requestBody.name, 'hello.png');
@@ -55,7 +55,7 @@ describe('Upload & Download tools', () => {
         contentBase64: 'aGVsbG8=',
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('name is required'));
+      assert.ok(res.content[0].text!.includes('name is required'));
     });
 
     it('uploads a new version of an existing file when fileId is provided', async () => {
@@ -64,7 +64,7 @@ describe('Upload & Download tools', () => {
         contentBase64: Buffer.from('new content').toString('base64'),
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Updated (new version)'));
+      assert.ok(res.content[0].text!.includes('Updated (new version)'));
       const updates = ctx.mocks.drive.tracker.getCalls('files.update');
       assert.equal(updates.length, 1);
       assert.equal(updates[0].args[0].fileId, 'file-1');
@@ -80,7 +80,7 @@ describe('Upload & Download tools', () => {
         convertToGoogleFormat: true,
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('convertToGoogleFormat'));
+      assert.ok(res.content[0].text!.includes('convertToGoogleFormat'));
     });
 
     it('rejects fileId combined with parentFolderId', async () => {
@@ -90,7 +90,7 @@ describe('Upload & Download tools', () => {
         parentFolderId: '/Work',
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('parentFolderId'));
+      assert.ok(res.content[0].text!.includes('parentFolderId'));
     });
 
     it('rejects in-place update of a Google Workspace file without explicit mimeType', async () => {
@@ -103,7 +103,7 @@ describe('Upload & Download tools', () => {
           contentBase64: 'aGVsbG8=',
         });
         assert.equal(res.isError, true);
-        assert.ok(res.content[0].text.includes('Google Workspace file'));
+        assert.ok(res.content[0].text!.includes('Google Workspace file'));
       } finally {
         ctx.mocks.drive.service.files.get._resetImpl();
       }
@@ -115,7 +115,7 @@ describe('Upload & Download tools', () => {
         name: 'bad.png',
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('valid base64'));
+      assert.ok(res.content[0].text!.includes('valid base64'));
       assert.equal(ctx.mocks.drive.tracker.getCalls('files.create').length, 0);
       assert.equal(ctx.mocks.drive.tracker.getCalls('files.update').length, 0);
     });
@@ -126,7 +126,7 @@ describe('Upload & Download tools', () => {
         name: 'blank.png',
       });
       assert.equal(res.isError, true);
-      assert.ok(res.content[0].text.includes('valid base64'));
+      assert.ok(res.content[0].text!.includes('valid base64'));
       assert.equal(ctx.mocks.drive.tracker.getCalls('files.create').length, 0);
     });
 
@@ -140,7 +140,7 @@ describe('Upload & Download tools', () => {
           localPath,
         });
         assert.equal(res.isError, false);
-        assert.ok(res.content[0].text.includes('Updated (new version)'));
+        assert.ok(res.content[0].text!.includes('Updated (new version)'));
         const updates = ctx.mocks.drive.tracker.getCalls('files.update');
         assert.equal(updates.length, 1);
         assert.equal(updates[0].args[0].fileId, 'file-1');
@@ -161,7 +161,7 @@ describe('Upload & Download tools', () => {
         mimeType: docxMime,
       });
       assert.equal(res.isError, false);
-      assert.ok(res.content[0].text.includes('Updated (new version)'));
+      assert.ok(res.content[0].text!.includes('Updated (new version)'));
       const updates = ctx.mocks.drive.tracker.getCalls('files.update');
       assert.equal(updates.length, 1);
       assert.equal(updates[0].args[0].fileId, 'doc-1');

--- a/test/schema/tool-registry.test.ts
+++ b/test/schema/tool-registry.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
 import { setupTestServer, type TestContext } from '../helpers/setup-server.js';
 
-const EXPECTED_TOOL_COUNT = 115;
+const EXPECTED_TOOL_COUNT = 116;
 
 const EXPECTED_TOOLS = [
   'manage_accounts',
@@ -18,7 +18,7 @@ const EXPECTED_TOOLS = [
   'setColumnWidth', 'setRowHeight', 'autoResizeColumns', 'autoResizeRows', 'hideSheetDimension', 'showSheetDimension',
   'listGoogleSheets', 'copyFile',
   'createGoogleSlides', 'updateGoogleSlides',
-  'getGoogleDocContent', 'getGoogleDocContentPaginated', 'getGoogleSlidesContent',
+  'getGoogleDocContent', 'getGoogleDocContentPaginated', 'getGoogleDocImage', 'getGoogleSlidesContent',
   'formatGoogleSlidesText', 'formatGoogleSlidesParagraph',
   'styleGoogleSlidesShape', 'setGoogleSlidesBackground',
   'createGoogleSlidesTextBox', 'createGoogleSlidesShape',


### PR DESCRIPTION
## Summary

Fixes #132. Google Doc readers gave the agent no way to reach an embedded inline image: `readGoogleDoc` (text + markdown) dropped images entirely, and `getGoogleDocContent`/`getGoogleDocContentPaginated` emitted an opaque `[image]` placeholder with no URL, id, or metadata. That silently broke OCR/vision/attachment-forwarding workflows.

This ships the fix in two halves, per maintainer direction (pointers alone don't help — a Docs `contentUri` expires ~30 min and nothing in this server fetches arbitrary URLs):

**1. Readers surface pointers + a durable `objectId`.** No API change — the document GET already returns `inlineObjects`.
- `readGoogleDoc` / `readGoogleDocPaginated`:
  - `markdown` → `![alt](contentUri "objectId=…")`
  - `text` → single-line `[image: objectId=… contentUri=… sourceUri=… size=WxHpt]`
- `getGoogleDocContent` / `getGoogleDocContentPaginated`: the bare `[image]` becomes the same self-describing token (objectId, contentUri/sourceUri, size, alt text).

The single-line tokens carry no newline (keeps index/pagination math intact) and no unescaped `|` (safe inside table cells). Alt text has its brackets/quotes escaped.

**2. New `getGoogleDocImage` tool** fetches an inline image's bytes by `(documentId, inlineObjectId)` — keyed by the durable objectId, never a raw (expiring) URI. It re-fetches the doc to resolve a **fresh** contentUri, downloads via the existing authenticated-request primitive, and returns a native **MCP image content block** the model can view. `outputFormat: "base64"` instead returns a `{ inlineObjectId, mimeType, byteLength, dataBase64 }` envelope for programmatic consumers (forwarding, save-to-disk). `ToolResult.content` is widened to carry image blocks (backward-compatible with every existing `{ type: "text", text }` site).

No inline base64 flag on the readers — it would balloon every read to megabytes of tokens (paid even when unused) and break the readers' newline-based pagination.

## Out of scope
Floating/anchored images stored as `positionedObjects` remain unrendered — documented as a known limitation in the CHANGELOG/README.

## Changes
- `src/tools/docs.ts` — shared helpers (`escapeBrackets`, `getInlineImageMeta`, `renderImagePlaceholder`, `renderImageMarkdown`, `findInlineObjectById`); thread `inlineObjects` + `format` through `extractText`/`extractDocText`; enrich `resolveInlineElementText`; new `getGoogleDocImage` schema + definition + handler.
- `src/types.ts` — widen `ToolResult.content` to allow image blocks.
- `src/tools/toolMeta.ts` — register `getGoogleDocImage` (read scope).
- `test/schema/tool-registry.test.ts` — tool count 115 → 116.
- `test/helpers/setup-server.ts` — per-test override for the auth client's `request` (for image fetching).
- `test/integration/docs.test.ts` — update 2 existing image tests; add reader + fetch-tool coverage.
- `CHANGELOG.md`, `README.md`.

## Testing
- `npm test` — 762 pass, 0 fail
- `npm run lint` (tsc + eslint) — clean
- New tests cover: markdown/text/indexed rendering, sourceUri-only, bracket/quote escaping, table-cell images, multi-tab + legacy resolution, paginated threading, and the `getGoogleDocImage` image/base64 outputs, mime-type parsing, multi-tab lookup, and error paths (missing id / no fetchable content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)