### PR TITLE
chore: prepare release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.5.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.4.0...v2.5.0) (2026-07-15)
+
+Surfaces **embedded inline images** in Google Docs instead of silently dropping them: the read tools now emit a self-describing image token, and a new **`getGoogleDocImage`** tool fetches an image's bytes on demand for OCR/vision workflows. Additive — no removed or renamed tools/parameters; existing single-user deployments are unaffected.
+
 ### Features
 
 - **docs:** surface embedded inline images instead of dropping or opaquely placeholdering them. `readGoogleDoc`/`readGoogleDocPaginated` now render each inline image (markdown → `![alt](contentUri "objectId=…")`; text → a single-line `[image: objectId=… contentUri=… sourceUri=… size=WxHpt]` token) instead of silently omitting it, and `getGoogleDocContent`/`getGoogleDocContentPaginated` upgrade the bare `[image]` placeholder to the same self-describing token (objectId, contentUri/sourceUri, size, alt text). A new **`getGoogleDocImage`** tool fetches an inline image's bytes by `(documentId, inlineObjectId)` — it re-fetches the doc to resolve a fresh, non-expired image URL and returns a native MCP image block (or, with `outputFormat: "base64"`, a `{ inlineObjectId, mimeType, byteLength, dataBase64 }` envelope) so downstream OCR/vision/forwarding workflows can reach the content. Keyed by the durable objectId (never a raw contentUri, which expires ~30 min). Floating/anchored images stored as `positionedObjects` remain unrendered (documented limitation) ([#132](https://github.com/piotr-agier/google-drive-mcp/issues/132))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "description": "Google Drive MCP Server - Model Context Protocol server providing secure access to Google Drive, Docs, Sheets, and Slides through MCP clients e.g. Claude Desktop",
     "license": "MIT",
     "author": "Piotr Agier <piotr.agier@gmail.com>",


### PR DESCRIPTION
Cuts **2.5.0** for the inline-images work ([#132](https://github.com/piotr-agier/google-drive-mcp/issues/132)) that merged to `master` after the v2.4.0 tag and was sitting in `[Unreleased]`.

## Changes
- Bump version `2.4.0` → `2.5.0` in `package.json` and `package-lock.json` (root package only; the `ts-api-utils@2.4.0` dependency is untouched).
- Move the `[Unreleased]` notes into a dated `## [2.5.0]` CHANGELOG section with a `v2.4.0...v2.5.0` compare link and a summary paragraph.

## Version choice — minor
The change is strictly additive at the public contract: a new `getGoogleDocImage` tool plus enriched output from the existing doc-read tools (previously-dropped inline images now surface as a self-describing token), with no removed or renamed tools/parameters. Consistent with the 2.4.0/2.3.0 precedent of reserving major for public-contract breaks.

## Verification
- `npm run build` (typecheck + bundle) passes.
- Diff is limited to `CHANGELOG.md`, `package.json`, `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)