### PR TITLE
chore: ignore local agent instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ Thumbs.db
 # Agent/tool config
 .codex/
 .claude/settings.local.json
+AGENTS.local.md
+CLAUDE.local.md
 
 # Test coverage
 coverage/


### PR DESCRIPTION
## Summary

- ignore `AGENTS.local.md`
- ignore `CLAUDE.local.md`
- keep machine-local agent guidance out of version control

## Verification

- confirmed both files resolve through `.gitignore`
- confirmed the commit changes only `.gitignore`