### PR TITLE
feat(docs): add baselineOffset (superscript/subscript) to applyTextStyle

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -491,6 +491,7 @@ function buildUpdateTextStyleRequest(
     foregroundColor?: string;
     backgroundColor?: string;
     linkUrl?: string;
+    baselineOffset?: 'SUPERSCRIPT' | 'SUBSCRIPT' | 'NONE';
   },
   tabId?: string
 ): { request: any; fields: string[] } | null {
@@ -521,6 +522,11 @@ function buildUpdateTextStyleRequest(
   if (style.linkUrl !== undefined) {
     textStyle.link = { url: style.linkUrl };
     fieldsToUpdate.push('link');
+  }
+
+  if (style.baselineOffset !== undefined) {
+    textStyle.baselineOffset = style.baselineOffset;
+    fieldsToUpdate.push('baselineOffset');
   }
 
   if (fieldsToUpdate.length === 0) return null;
@@ -1313,6 +1319,7 @@ const ApplyTextStyleSchema = z.object({
   foregroundColor: z.string().optional(),
   backgroundColor: z.string().optional(),
   linkUrl: z.string().url().optional(),
+  baselineOffset: z.enum(['SUPERSCRIPT', 'SUBSCRIPT', 'NONE']).optional(),
   tabId: z.string().optional()
 });
 
@@ -1613,6 +1620,7 @@ export const toolDefinitions: ToolDefinition[] = [
         foregroundColor: { type: "string", description: "Hex color (e.g., #FF0000)" },
         backgroundColor: { type: "string", description: "Hex background color" },
         linkUrl: { type: "string", description: "URL for hyperlink" },
+        baselineOffset: { type: "string", enum: ["SUPERSCRIPT", "SUBSCRIPT", "NONE"], description: "Vertical text offset: SUPERSCRIPT or SUBSCRIPT. Use NONE to reset text to the normal baseline." },
         tabId: { type: "string", description: "Optional. Tab ID to format within (from listDocumentTabs). If omitted, operates on the first/default tab." }
       },
       required: ["documentId"]
@@ -2784,7 +2792,8 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
         fontFamily: a.fontFamily,
         foregroundColor: a.foregroundColor,
         backgroundColor: a.backgroundColor,
-        linkUrl: a.linkUrl
+        linkUrl: a.linkUrl,
+        baselineOffset: a.baselineOffset
       };
 
       // Build the update request

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -867,6 +867,21 @@ describe('Docs tools', () => {
       const res = await callTool(ctx.client, 'applyTextStyle', {});
       assert.equal(res.isError, true);
     });
+
+    it('accepts baselineOffset as the only style option', async () => {
+      const res = await callTool(ctx.client, 'applyTextStyle', {
+        documentId: 'doc-1', startIndex: 1, endIndex: 5, baselineOffset: 'SUPERSCRIPT',
+      });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text!.includes('applied text style'));
+    });
+
+    it('rejects an invalid baselineOffset value', async () => {
+      const res = await callTool(ctx.client, 'applyTextStyle', {
+        documentId: 'doc-1', startIndex: 1, endIndex: 5, baselineOffset: 'MIDDLE',
+      });
+      assert.equal(res.isError, true);
+    });
   });
 
   // --- applyParagraphStyle ---
@@ -2527,6 +2542,22 @@ describe('Docs tools', () => {
         assert.ok(res.content[0].text!.includes('listDocumentTabs'));
         assert.equal(ctx.mocks.docs.tracker.getCalls('documents.batchUpdate').length, before);
         ctx.mocks.docs.service.documents.get._resetImpl();
+      });
+
+      it('sends baselineOffset in the updateTextStyle payload with a matching field mask', async () => {
+        const res = await callTool(ctx.client, 'applyTextStyle', { documentId: 'doc-1', startIndex: 1, endIndex: 5, baselineOffset: 'SUBSCRIPT' });
+        assert.equal(res.isError, false);
+        const req = lastRequests()[0].updateTextStyle;
+        assert.equal(req.textStyle.baselineOffset, 'SUBSCRIPT');
+        assert.ok(req.fields.split(',').includes('baselineOffset'));
+      });
+
+      it('passes NONE through so existing super/subscript can be reset', async () => {
+        const res = await callTool(ctx.client, 'applyTextStyle', { documentId: 'doc-1', startIndex: 1, endIndex: 5, baselineOffset: 'NONE' });
+        assert.equal(res.isError, false);
+        const req = lastRequests()[0].updateTextStyle;
+        assert.equal(req.textStyle.baselineOffset, 'NONE');
+        assert.ok(req.fields.split(',').includes('baselineOffset'));
       });
     });
 


### PR DESCRIPTION
## What

Adds an optional `baselineOffset` parameter (`SUPERSCRIPT` | `SUBSCRIPT` | `NONE`) to `applyTextStyle` / `formatGoogleDocText`, mapped straight onto the Docs API's `textStyle.baselineOffset`. `NONE` resets previously offset text to the normal baseline.

This fills a small formatting gap — there was previously no way to produce superscript/subscript text (e.g. H₂O, footnote markers, exponents) through the MCP.

## Changes

- `ApplyTextStyleSchema` + the tool's JSON `inputSchema` gain the enum (kept in parity for the schema-registry test)
- `buildUpdateTextStyleRequest` maps it into `textStyle` and the field mask
- 4 new integration tests (payload + field-mask assertions, validation rejection, `NONE` passthrough)

## Testing

- Full suite passes (773/773)
- Live-tested against a real Google Doc via the stdio server: applied SUPERSCRIPT and SUBSCRIPT via `textToFind`, confirmed `textStyle.baselineOffset` on the affected runs through a direct `documents.get`, and confirmed `NONE` clears the offset. Works with `tabId` targeting as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)