### PR TITLE
fix(docs): render headings, emphasis, lists and tables in format="markdown" reads

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -167,13 +167,67 @@ function renderImageMarkdown(meta: InlineImageMeta | null): string {
   return `![${alt}](${escapeMarkdownUri(uri)} "objectId=${meta.objectId}")`;
 }
 
-// Extract plain text from body content (paragraphs + tables). Inline images are
+// Google Docs named paragraph styles that map onto ATX headings.
+const MARKDOWN_HEADING_PREFIX: Record<string, string> = {
+  HEADING_1: '#',
+  HEADING_2: '##',
+  HEADING_3: '###',
+  HEADING_4: '####',
+  HEADING_5: '#####',
+  HEADING_6: '######',
+};
+
+// `# ` / `## ` / … for a heading paragraph, '' for body text.
+function markdownHeadingPrefix(paragraph: any): string {
+  const hashes = MARKDOWN_HEADING_PREFIX[paragraph?.paragraphStyle?.namedStyleType];
+  return hashes ? `${hashes} ` : '';
+}
+
+// `- ` / `1. ` (indented by nesting level) for a list paragraph, '' otherwise.
+// Ordered vs unordered comes from the list definition: ordered nesting levels
+// carry a `glyphType`, unordered ones a `glyphSymbol`.
+function markdownListPrefix(paragraph: any, lists?: any): string {
+  const bullet = paragraph?.bullet;
+  if (!bullet) return '';
+  const nestingLevel = bullet.nestingLevel ?? 0;
+  const level = lists?.[bullet.listId]?.listProperties?.nestingLevels?.[nestingLevel];
+  const glyphType = level?.glyphType;
+  const ordered = !!glyphType && glyphType !== 'NONE' && glyphType !== 'GLYPH_TYPE_UNSPECIFIED';
+  // Every ordered item is emitted as `1.` — markdown renderers renumber
+  // automatically, and the Docs model has no reliable per-item ordinal here.
+  return `${'  '.repeat(nestingLevel)}${ordered ? '1. ' : '- '}`;
+}
+
+// Wrap a text run in markdown emphasis. Markers are kept tight against the
+// visible text — surrounding whitespace, including the paragraph's trailing
+// newline, stays outside, otherwise the emphasis span never closes.
+function applyMarkdownEmphasis(content: string, textStyle: any): string {
+  if (!textStyle) return content;
+  const open: string[] = [];
+  if (textStyle.bold) open.push('**');
+  if (textStyle.italic) open.push('*');
+  if (textStyle.strikethrough) open.push('~~');
+  if (open.length === 0) return content;
+
+  const [, lead, core, trail] = /^(\s*)([\s\S]*?)(\s*)$/.exec(content) ?? [];
+  if (!core) return content;
+  const close = [...open].reverse();
+  return `${lead}${open.join('')}${core}${close.join('')}${trail}`;
+}
+
+// Extract text from body content (paragraphs + tables). Inline images are
 // rendered from `inlineObjects` (markdown `![alt](uri)` or a single-line
 // placeholder) instead of being dropped.
+//
+// In markdown mode the document's structure is carried over too: heading
+// paragraphs get their ATX prefix, list paragraphs a `- `/`1. ` marker indented
+// by nesting level, styled runs their emphasis markers, and tables render as
+// pipe tables. Text mode is unchanged — plain runs, tab-separated table cells.
 function extractText(
   bodyContent: any[],
   inlineObjects?: any,
-  format: 'text' | 'markdown' = 'text'
+  format: 'text' | 'markdown' = 'text',
+  lists?: any
 ): string {
   const renderImage = (id: string): string =>
     format === 'markdown'
@@ -183,14 +237,55 @@ function extractText(
   let result = '';
   for (const element of bodyContent) {
     if (element.paragraph?.elements) {
+      let paragraphText = '';
       for (const elem of element.paragraph.elements) {
         if (elem.textRun?.content) {
-          result += elem.textRun.content;
+          paragraphText += format === 'markdown'
+            ? applyMarkdownEmphasis(elem.textRun.content, elem.textRun.textStyle)
+            : elem.textRun.content;
         } else if (elem.inlineObjectElement?.inlineObjectId) {
-          result += renderImage(elem.inlineObjectElement.inlineObjectId);
+          paragraphText += renderImage(elem.inlineObjectElement.inlineObjectId);
         }
       }
+      if (format === 'markdown' && paragraphText.trim() !== '') {
+        // Skip empty paragraphs — a bare `## ` or `- ` is not a heading or a
+        // list item, and would survive a markdown round trip as visible junk.
+        // A bulleted paragraph reads as a list item even when it also carries a
+        // heading style, so the list prefix wins.
+        paragraphText = element.paragraph.bullet
+          ? markdownListPrefix(element.paragraph, lists) + paragraphText
+          : markdownHeadingPrefix(element.paragraph) + paragraphText;
+      }
+      result += paragraphText;
+    } else if (element.table && format === 'markdown') {
+      const rows = element.table.tableRows || [];
+      rows.forEach((row: any, rowIdx: number) => {
+        const cells = (row.tableCells || []).map((cell: any) => {
+          let cellText = '';
+          for (const cellContent of cell.content || []) {
+            if (cellContent.paragraph?.elements) {
+              for (const elem of cellContent.paragraph.elements) {
+                if (elem.textRun?.content) {
+                  cellText += applyMarkdownEmphasis(elem.textRun.content, elem.textRun.textStyle);
+                } else if (elem.inlineObjectElement?.inlineObjectId) {
+                  cellText += renderImage(elem.inlineObjectElement.inlineObjectId);
+                }
+              }
+            }
+          }
+          // A cell spanning multiple paragraphs collapses to one line — a
+          // newline would terminate the table row. `|` must be escaped or it
+          // would read as a column separator.
+          return cellText.replace(/\s*\n\s*/g, ' ').replace(/\|/g, '\\|').trim();
+        });
+        result += `| ${cells.join(' | ')} |\n`;
+        if (rowIdx === 0) {
+          result += `| ${cells.map(() => '---').join(' | ')} |\n`;
+        }
+      });
+      result += '\n';
     } else if (element.table) {
+      // Text mode: the legacy tab-separated rendering, left untouched.
       for (const row of element.table.tableRows || []) {
         for (const cell of row.tableCells || []) {
           for (const cellContent of cell.content || []) {
@@ -230,7 +325,7 @@ function extractDocText(
       }
       const bodyContent = tab.documentTab?.body?.content;
       if (bodyContent) {
-        text = extractText(bodyContent, tab.documentTab?.inlineObjects, format);
+        text = extractText(bodyContent, tab.documentTab?.inlineObjects, format, tab.documentTab?.lists);
       }
     } else {
       const allTabs = collectAllTabsWithLevel(tabs);
@@ -243,7 +338,7 @@ function extractDocText(
           text += `${indent}=== Tab: ${title} ===\n`;
         }
         if (bodyContent) {
-          text += extractText(bodyContent, tab.documentTab?.inlineObjects, format);
+          text += extractText(bodyContent, tab.documentTab?.inlineObjects, format, tab.documentTab?.lists);
         }
         if (isMultiTab) {
           text += '\n';
@@ -253,7 +348,7 @@ function extractDocText(
   } else {
     const body = doc.body;
     if (body?.content) {
-      text = extractText(body.content, doc.inlineObjects, format);
+      text = extractText(body.content, doc.inlineObjects, format, doc.lists);
     }
   }
 

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -641,6 +641,232 @@ describe('Docs tools', () => {
       assert.ok(res.content[0].text!.includes('![Architecture diagram](https://lh3.googleusercontent.com/xyz "objectId=obj-1")'), res.content[0].text!);
     });
 
+    it('renders heading paragraphs as ATX hashes (format=markdown)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with headings',
+          body: {
+            content: [
+              { paragraph: { paragraphStyle: { namedStyleType: 'HEADING_1' }, elements: [{ textRun: { content: 'Top level\n' } }] } },
+              { paragraph: { paragraphStyle: { namedStyleType: 'HEADING_3' }, elements: [{ textRun: { content: 'Third level\n' } }] } },
+              { paragraph: { paragraphStyle: { namedStyleType: 'NORMAL_TEXT' }, elements: [{ textRun: { content: 'Plain body\n' } }] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('# Top level\n'), text);
+      assert.ok(text.includes('### Third level\n'), text);
+      assert.ok(text.includes('Plain body\n'), text);
+      assert.ok(!text.includes('# Plain body'), text);
+    });
+
+    it('does not emit a bare hash for an empty heading paragraph (format=markdown)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with empty heading',
+          body: {
+            content: [
+              { paragraph: { paragraphStyle: { namedStyleType: 'HEADING_2' }, elements: [{ textRun: { content: '\n' } }] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(!text.includes('## '), text);
+    });
+
+    it('leaves headings unprefixed in text format', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with headings',
+          body: {
+            content: [
+              { paragraph: { paragraphStyle: { namedStyleType: 'HEADING_1' }, elements: [{ textRun: { content: 'Top level\n' } }] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'text' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('Top level'), text);
+      assert.ok(!text.includes('#'), text);
+    });
+
+    it('wraps bold, italic and strikethrough runs in emphasis (format=markdown)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with emphasis',
+          body: {
+            content: [
+              { paragraph: { elements: [
+                { textRun: { content: 'plain ' } },
+                { textRun: { content: 'bold', textStyle: { bold: true } } },
+                { textRun: { content: ' and ' } },
+                { textRun: { content: 'italic', textStyle: { italic: true } } },
+                { textRun: { content: ' and ' } },
+                { textRun: { content: 'struck', textStyle: { strikethrough: true } } },
+                { textRun: { content: '\n' } },
+              ] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('plain **bold** and *italic* and ~~struck~~'), text);
+    });
+
+    it('keeps emphasis markers tight around a run that ends the paragraph (format=markdown)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with trailing emphasis',
+          body: {
+            content: [
+              { paragraph: { elements: [
+                { textRun: { content: 'lead ' } },
+                { textRun: { content: 'bold tail\n', textStyle: { bold: true } } },
+              ] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      // The newline must fall outside the markers, otherwise the emphasis never closes.
+      assert.ok(text.includes('lead **bold tail**\n'), JSON.stringify(text));
+      assert.ok(!text.includes('\n**'), JSON.stringify(text));
+    });
+
+    it('leaves emphasis unmarked in text format', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with emphasis',
+          body: {
+            content: [
+              { paragraph: { elements: [
+                { textRun: { content: 'bold', textStyle: { bold: true } } },
+                { textRun: { content: '\n' } },
+              ] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'text' });
+      assert.equal(res.isError, false);
+      assert.ok(!res.content[0].text!.includes('*'), res.content[0].text!);
+    });
+
+    it('renders bulleted and numbered list items with nesting (format=markdown)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with lists',
+          body: {
+            content: [
+              { paragraph: { bullet: { listId: 'l1', nestingLevel: 0 }, elements: [{ textRun: { content: 'first\n' } }] } },
+              { paragraph: { bullet: { listId: 'l1', nestingLevel: 1 }, elements: [{ textRun: { content: 'nested\n' } }] } },
+              { paragraph: { bullet: { listId: 'l2', nestingLevel: 0 }, elements: [{ textRun: { content: 'step one\n' } }] } },
+            ],
+          },
+          lists: {
+            l1: { listProperties: { nestingLevels: [{ glyphSymbol: '●' }, { glyphSymbol: '○' }] } },
+            l2: { listProperties: { nestingLevels: [{ glyphType: 'DECIMAL' }] } },
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('- first\n'), JSON.stringify(text));
+      assert.ok(text.includes('  - nested\n'), JSON.stringify(text));
+      assert.ok(text.includes('1. step one\n'), JSON.stringify(text));
+    });
+
+    it('renders a bulleted heading as a list item, not a heading (format=markdown)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with bulleted heading',
+          body: {
+            content: [
+              { paragraph: { paragraphStyle: { namedStyleType: 'HEADING_2' }, bullet: { listId: 'l1', nestingLevel: 0 }, elements: [{ textRun: { content: 'item\n' } }] } },
+            ],
+          },
+          lists: { l1: { listProperties: { nestingLevels: [{ glyphSymbol: '●' }] } } },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('- item\n'), JSON.stringify(text));
+      assert.ok(!text.includes('## item'), JSON.stringify(text));
+    });
+
+    it('renders tables as pipe tables (format=markdown)', async () => {
+      const cell = (content: string) => ({ content: [{ paragraph: { elements: [{ textRun: { content } }] } }] });
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with table',
+          body: {
+            content: [
+              { table: { tableRows: [
+                { tableCells: [cell('Owner'), cell('Role')] },
+                { tableCells: [cell('Eero'), cell('CEO')] },
+              ] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('| Owner | Role |'), JSON.stringify(text));
+      assert.ok(text.includes('| --- | --- |'), JSON.stringify(text));
+      assert.ok(text.includes('| Eero | CEO |'), JSON.stringify(text));
+    });
+
+    it('escapes pipe characters inside table cells (format=markdown)', async () => {
+      const cell = (content: string) => ({ content: [{ paragraph: { elements: [{ textRun: { content } }] } }] });
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with pipe',
+          body: {
+            content: [
+              { table: { tableRows: [{ tableCells: [cell('a | b'), cell('c')] }] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'markdown' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text!.includes('| a \\| b | c |'), JSON.stringify(res.content[0].text!));
+    });
+
+    it('keeps tables tab-separated in text format', async () => {
+      const cell = (content: string) => ({ content: [{ paragraph: { elements: [{ textRun: { content } }] } }] });
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'Doc with table',
+          body: {
+            content: [
+              { table: { tableRows: [{ tableCells: [cell('Owner'), cell('Role')] }] } },
+            ],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'readGoogleDoc', { documentId: 'doc-1', format: 'text' });
+      assert.equal(res.isError, false);
+      const text = res.content[0].text!;
+      assert.ok(text.includes('Owner\tRole\t'), JSON.stringify(text));
+      assert.ok(!text.includes('|'), JSON.stringify(text));
+    });
+
     it('renders inline images as a single-line placeholder (format=text)', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({
         data: {


### PR DESCRIPTION
Fixes #160.

## The problem

`readGoogleDoc` / `readGoogleDocPaginated` accept `format: "markdown"`, but `extractText()` only branched on the format for image rendering. Every other structural signal in the document was concatenated as raw text, so the output was plain text wearing a markdown label — the only `#` in it was the document title, which the handler prepends unconditionally.

The practical consequence: a **read-as-markdown → edit → write-back round trip silently flattens every heading** in the document. Nothing errors, so it's invisible until someone opens the doc.

## The change

All of it is confined to markdown mode; `format: "text"` output is byte-for-byte unchanged.

| Element | Rendering |
|---|---|
| Headings | `paragraphStyle.namedStyleType` HEADING_1..6 → `#`..`######` |
| Emphasis | `textStyle` bold / italic / strikethrough → `**` / `*` / `~~` |
| Lists | `bullet` → `- ` or `1. `, indented by nesting level |
| Tables | pipe tables with a header separator |

Three edge cases handled deliberately, since each one breaks a round trip:

- **Emphasis markers stay tight against the visible text.** A run ending in the paragraph's trailing newline emits `**text**\n`, not `**text\n**` — the latter never closes the span.
- **Empty paragraphs stay unprefixed.** A bare `## ` or `- ` is not a heading or a list item, and would survive a round trip as visible junk.
- **A bulleted paragraph that also carries a heading style renders as a list item**, not as both.

One deliberate simplification: every ordered item emits `1.`. Markdown renderers renumber automatically, and the Docs model doesn't expose a reliable per-item ordinal at this layer. Flagged in a code comment.

## On the list schema — verified, not assumed

Ordered vs unordered is resolved from the list definition, which meant threading `lists` through to the extractor. I checked the shape against live Google Docs API responses rather than trusting the reference docs, and two details would have been easy to get wrong:

- For tabbed documents, `lists` hangs off **`documentTab`**, not the document root.
- **`bullet.nestingLevel` is omitted entirely at level 0**, so it has to be defaulted rather than read.

Confirmed on real payloads: ordered nesting levels carry `glyphType: "DECIMAL"`, unordered ones carry `glyphSymbol: "●"`.

## Tests

11 new tests in `test/integration/docs.test.ts`, alongside the existing markdown image tests and following their mocking conventions. Each was written first and watched fail before the implementing code existed.

Included are three regression guards asserting that **text format remains unaffected** — headings unprefixed, emphasis unmarked, table cells tab-separated.

Full suite: **784 tests, 783 passing.** The single failure is `FileTeamStore: store file is created with mode 0600`, which fails identically on an unmodified checkout — it asserts POSIX file permissions and I'm on Windows. `npm run lint` (tsc + eslint) is clean.

Happy to split this into per-element commits, adjust the ordered-list handling, or drop the table rendering if you'd rather keep the diff tighter — just say which.
