### PR TITLE
fix(auth): evict cached clients on re-consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **auth:** re-authenticating an existing account with `manage_accounts add <alias>` now takes effect immediately instead of requiring a server restart. The refreshed grant was persisted correctly, but the OAuth client cached for that alias — and the Drive/Calendar services built on it — were left in place, so every subsequent call kept using the superseded (often revoked) grant and failed with "authorization was revoked or has expired". A completed re-consent now evicts those cached clients, the way removing an account already did ([#168](https://github.com/piotr-agier/google-drive-mcp/issues/168))
 - **docs:** `formatGoogleDocText` now advertises `baselineOffset` in its input schema. The alias shares a handler and validation schema with `applyTextStyle`, so the parameter already worked at runtime, but it was missing from the advertised tool definition — clients that build arguments from (or validate against) the published schema could not reach superscript/subscript through the alias
 
 ## [2.5.1](https://github.com/piotr-agier/google-drive-mcp/compare/v2.5.0...v2.5.1) (2026-07-17)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -175,7 +175,7 @@ One admin tool drives the whole lifecycle. It ignores the `account` parameter an
 | Action | `account_id` | What it does |
 |---|---|---|
 | `list` | — | Returns all connected accounts with alias, email, `sub`, scopes, expiry, and which is the default. Never returns tokens. |
-| `add` | required (alias) | Starts an OAuth flow in your browser with `prompt=consent select_account` and `access_type=offline`, so Google shows an account picker and always returns a refresh token. On success, the new record is written to `tokens.json`. If it's the first account, it also becomes the default. |
+| `add` | required (alias) | Starts an OAuth flow in your browser with `prompt=consent select_account` and `access_type=offline`, so Google shows an account picker and always returns a refresh token. On success, the new record is written to `tokens.json`. If it's the first account, it also becomes the default. Re-running `add` for an existing alias re-consents that account in place (to broaden scopes or recover a revoked grant); the refreshed grant takes effect on the next call, with no server restart. |
 | `remove` | required (alias) | Deletes the account's credentials from `tokens.json` and clears it from the default if applicable. The token is **not** revoked server-side — see [Revoking OAuth access](#revoking-oauth-access). |
 | `set_default` | required (alias, or `"null"` to clear) | Picks which account is used when a tool call omits `account`. |
 

--- a/src/auth/accountClientFactory.ts
+++ b/src/auth/accountClientFactory.ts
@@ -54,7 +54,8 @@ export class AccountClientFactory {
     return client;
   }
 
-  /** Drop a cached client (e.g. after `remove`). */
+  /** Drop a cached client (e.g. after `remove`, or a re-consent that
+   *  supersedes the grant it was built from). */
   evict(alias: string): void {
     this.clients.delete(alias);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,18 @@ async function getAuthClientFor(account: AccountRecord): Promise<any> {
   return sys.factory.getClient(account.alias);
 }
 
+/**
+ * Drop every client cached for `alias` — the factory's OAuth2Client plus the
+ * Drive and Calendar services built on it. Call whenever the alias's grant
+ * changes (removal, or a re-consent that supersedes the old tokens) so the next
+ * call rebuilds from the current record instead of a revoked one.
+ */
+function evictAccountClients(alias: string): void {
+  requireAuthSystem().factory.evict(alias);
+  _driveByAlias.delete(alias);
+  _calendarByAlias.delete(alias);
+}
+
 // -----------------------------------------------------------------------------
 // Account lifecycle API (consumed by `manage_accounts` handler via ctx)
 // -----------------------------------------------------------------------------
@@ -256,6 +268,11 @@ async function addAccountFlow(alias: string, openBrowser = true): Promise<AddAcc
           pendingIdentity,
         };
         await sys.store.upsert(record);
+        // A re-consent supersedes the grant every cached client for this alias
+        // was built from (issue #168): without this the factory keeps handing
+        // out the old — possibly revoked — OAuth2Client, and the cached Drive
+        // and Calendar services stay bound to it, until the server restarts.
+        evictAccountClients(alias);
         // Make it the default if it's the first account.
         if (!sys.store.getDefault()) {
           await sys.store.setDefault(alias);
@@ -306,9 +323,7 @@ async function removeAccountFlow(alias: string): Promise<void> {
     throw new Error(`No account with alias "${alias}".`);
   }
   await sys.store.remove(alias);
-  sys.factory.evict(alias);
-  _driveByAlias.delete(alias);
-  _calendarByAlias.delete(alias);
+  evictAccountClients(alias);
 }
 
 async function setDefaultAccountFlow(alias: string | null): Promise<void> {
@@ -1584,6 +1599,35 @@ export function _setAuthClientForTesting(client: any) {
  */
 export function _getAuthSystemForTesting(): AuthSystem | null {
   return authSystem;
+}
+
+/**
+ * Install (or clear) an arbitrary AuthSystem for testing, and drop every cached
+ * Drive/Calendar service so the next call rebuilds through the new system.
+ *
+ * `_setAuthClientForTesting` always builds a `mode: 'test'` system, which makes
+ * the account-lifecycle flows unreachable (they short-circuit in
+ * `requireLocalOAuthMode`). This hook lets a test stand up a real local-OAuth
+ * system over a temporary `tokens.json` and drive `add`/`remove` end to end.
+ */
+export function _setAuthSystemForTesting(sys: AuthSystem | null): void {
+  authSystem = sys;
+  _driveByAlias.clear();
+  _calendarByAlias.clear();
+}
+
+/**
+ * Run the real `manage_accounts add` flow for testing.
+ *
+ * `openBrowser` defaults to false here (the tool handler passes true): a test
+ * must never have `AuthServer.start` launch a browser — it drives the OAuth
+ * callback with an HTTP request instead.
+ */
+export function _addAccountFlowForTesting(
+  alias: string,
+  openBrowser = false,
+): Promise<AddAccountResult> {
+  return addAccountFlow(alias, openBrowser);
 }
 
 /**

--- a/test/integration/reauth-evicts-clients.test.ts
+++ b/test/integration/reauth-evicts-clients.test.ts
@@ -92,6 +92,7 @@ describe('re-consent evicts cached clients (issue #168)', () => {
   let ctx: TestContext;
   let serverModule: any;
   let sys: AuthSystem;
+  let tmpDir: string;
   let tokenPath: string;
   let originalDriveFactory: typeof google.drive;
   let driveAuths: unknown[] = [];
@@ -102,16 +103,16 @@ describe('re-consent evicts cached clients (issue #168)', () => {
     ctx = await setupTestServer();
     serverModule = await import('../../src/index.js');
 
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'gdrive-mcp-reauth-'));
-    tokenPath = path.join(dir, 'tokens.json');
-    const credsPath = path.join(dir, 'gcp-oauth.keys.json');
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gdrive-mcp-reauth-'));
+    tokenPath = path.join(tmpDir, 'tokens.json');
+    const credsPath = path.join(tmpDir, 'gcp-oauth.keys.json');
     await fs.writeFile(
       credsPath,
       JSON.stringify({
         installed: {
           client_id: 'test-client-id.apps.googleusercontent.com',
           client_secret: 'test-client-secret',
-          redirect_uris: [`http://localhost:${AUTH_PORT}/oauth2callback`],
+          redirect_uris: [`http://127.0.0.1:${AUTH_PORT}/oauth2callback`],
         },
       }),
     );
@@ -172,6 +173,9 @@ describe('re-consent evicts cached clients (issue #168)', () => {
     // and leave the module in the state other suites expect.
     serverModule._setAuthClientForTesting({});
     await ctx.cleanup();
+    // The temp dir holds a tokens.json and a credentials file; don't leave them
+    // behind in os.tmpdir() on every run.
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
   it('a completed re-consent takes effect without restarting the server', async () => {
@@ -187,7 +191,9 @@ describe('re-consent evicts cached clients (issue #168)', () => {
 
     // 2. Re-consent the same alias through the real flow.
     const { completion } = await serverModule._addAccountFlowForTesting('work');
-    const callback = await fetch(`http://localhost:${AUTH_PORT}/oauth2callback?code=x`);
+    // 127.0.0.1, not `localhost`: AuthServer binds the loopback IP explicitly so
+    // the bind and the redirect URI agree on dual-stack hosts (see auth/server.ts).
+    const callback = await fetch(`http://127.0.0.1:${AUTH_PORT}/oauth2callback?code=x`);
     assert.equal(callback.status, 200);
     const record = await completion;
 

--- a/test/integration/reauth-evicts-clients.test.ts
+++ b/test/integration/reauth-evicts-clients.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import { describe, it, before, after } from 'node:test';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+
+import { setupTestServer, callTool, type TestContext } from '../helpers/setup-server.js';
+import {
+  AccountClientFactory,
+  AccountResolver,
+  AccountStore,
+  DEFAULT_SCOPES,
+  SessionStore,
+  type AuthSystem,
+} from '../../src/auth.js';
+import type { AccountRecord } from '../../src/auth/types.js';
+
+// ---------------------------------------------------------------------------
+// Re-consent must invalidate every cached client (issue #168).
+//
+// `manage_accounts add <existing-alias>` re-consents in place. Before the fix
+// it only wrote the new record: the factory kept handing out the OAuth2Client
+// built from the superseded (often revoked) grant, and the per-alias Drive and
+// Calendar services stayed bound to it, so every call failed until the server
+// was restarted.
+//
+// This drives the real flow — a local-OAuth AuthSystem over a temp tokens.json,
+// the real AuthServer answering a real HTTP callback — with the code-for-tokens
+// exchange stubbed, so no network reaches Google.
+// ---------------------------------------------------------------------------
+
+const AUTH_PORT = 18680;
+const OLD_ACCESS = 'old-access';
+const NEW_ACCESS = 'reauth-access';
+const HOUR_MS = 60 * 60 * 1000;
+
+function makeStoredRecord(): AccountRecord {
+  const now = new Date().toISOString();
+  return {
+    alias: 'work',
+    email: 'work@example.com',
+    sub: 'sub-work',
+    accessToken: OLD_ACCESS,
+    refreshToken: 'old-refresh',
+    scope: DEFAULT_SCOPES.join(' '),
+    tokenType: 'Bearer',
+    // Far-future expiry so nothing in this test triggers a real token refresh.
+    expiryDate: Date.now() + HOUR_MS,
+    addedAt: now,
+    lastRefreshedAt: now,
+  };
+}
+
+/** Stub the code-for-tokens exchange; returns a restore function. */
+function stubGetToken(): () => void {
+  const original = OAuth2Client.prototype.getToken;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (OAuth2Client.prototype as any).getToken = async () => ({
+    tokens: {
+      access_token: NEW_ACCESS,
+      refresh_token: 'reauth-refresh',
+      scope: DEFAULT_SCOPES.join(' '),
+      token_type: 'Bearer',
+      expiry_date: Date.now() + HOUR_MS,
+    },
+    res: null,
+  });
+  return () => {
+    OAuth2Client.prototype.getToken = original;
+  };
+}
+
+/**
+ * Fail the userinfo lookup `addAccountFlow` performs after consent. Keeps the
+ * test offline and exercises the documented fallback: a re-consent must not
+ * regress a known email/sub when identity resolution fails.
+ */
+function stubRequestFailure(): () => void {
+  const original = OAuth2Client.prototype.request;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (OAuth2Client.prototype as any).request = async () => {
+    throw new Error('userinfo unavailable in tests');
+  };
+  return () => {
+    OAuth2Client.prototype.request = original;
+  };
+}
+
+describe('re-consent evicts cached clients (issue #168)', () => {
+  let ctx: TestContext;
+  let serverModule: any;
+  let sys: AuthSystem;
+  let tokenPath: string;
+  let originalDriveFactory: typeof google.drive;
+  let driveAuths: unknown[] = [];
+  const savedEnv: Record<string, string | undefined> = {};
+  const restores: Array<() => void> = [];
+
+  before(async () => {
+    ctx = await setupTestServer();
+    serverModule = await import('../../src/index.js');
+
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'gdrive-mcp-reauth-'));
+    tokenPath = path.join(dir, 'tokens.json');
+    const credsPath = path.join(dir, 'gcp-oauth.keys.json');
+    await fs.writeFile(
+      credsPath,
+      JSON.stringify({
+        installed: {
+          client_id: 'test-client-id.apps.googleusercontent.com',
+          client_secret: 'test-client-secret',
+          redirect_uris: [`http://localhost:${AUTH_PORT}/oauth2callback`],
+        },
+      }),
+    );
+    await fs.writeFile(
+      tokenPath,
+      JSON.stringify({
+        version: 2,
+        defaultAccount: 'work',
+        accounts: { work: makeStoredRecord() },
+      }),
+    );
+
+    for (const key of [
+      'GOOGLE_DRIVE_MCP_TOKEN_PATH',
+      'GOOGLE_DRIVE_OAUTH_CREDENTIALS',
+      'GOOGLE_DRIVE_MCP_AUTH_PORT',
+    ]) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.GOOGLE_DRIVE_MCP_TOKEN_PATH = tokenPath;
+    process.env.GOOGLE_DRIVE_OAUTH_CREDENTIALS = credsPath;
+    process.env.GOOGLE_DRIVE_MCP_AUTH_PORT = String(AUTH_PORT);
+
+    // A real local-OAuth auth system in place of the harness's 'test' mode one,
+    // so the account-lifecycle flows don't short-circuit in requireLocalOAuthMode.
+    const store = new AccountStore({ filePath: tokenPath, mode: 'local-oauth' });
+    await store.reload();
+    const sessions = new SessionStore();
+    const factory = new AccountClientFactory(store);
+    sys = {
+      mode: 'local-oauth',
+      store,
+      factory,
+      resolver: new AccountResolver(store, sessions),
+      sessions,
+    };
+    serverModule._setAuthSystemForTesting(sys);
+
+    // Record the auth client every Drive service is constructed with, so a
+    // cached-vs-rebuilt service is directly observable.
+    originalDriveFactory = google.drive as any;
+    (google as any).drive = (opts: any) => {
+      driveAuths.push(opts?.auth);
+      return originalDriveFactory(opts);
+    };
+
+    restores.push(stubGetToken(), stubRequestFailure());
+  });
+
+  after(async () => {
+    (google as any).drive = originalDriveFactory;
+    for (const restore of restores) restore();
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    // Restore the shared 'test'-mode auth system for any later test in this file
+    // and leave the module in the state other suites expect.
+    serverModule._setAuthClientForTesting({});
+    await ctx.cleanup();
+  });
+
+  it('a completed re-consent takes effect without restarting the server', async () => {
+    // 1. Prime the caches: this builds the factory client plus the per-alias
+    //    Drive and Calendar services from the stored (soon-to-be-stale) grant.
+    const primed = await callTool(ctx.client, 'search', { query: 'q', account: 'work' });
+    assert.notEqual(primed.isError, true, `priming call errored: ${JSON.stringify(primed)}`);
+
+    const clientBefore = await sys.factory.getClient('work');
+    assert.equal(clientBefore.credentials.access_token, OLD_ACCESS);
+    assert.ok(driveAuths.length > 0, 'priming call should have built a Drive service');
+    driveAuths = [];
+
+    // 2. Re-consent the same alias through the real flow.
+    const { completion } = await serverModule._addAccountFlowForTesting('work');
+    const callback = await fetch(`http://localhost:${AUTH_PORT}/oauth2callback?code=x`);
+    assert.equal(callback.status, 200);
+    const record = await completion;
+
+    // The failed userinfo lookup must not regress the known identity.
+    assert.equal(record.email, 'work@example.com');
+    assert.equal(record.sub, 'sub-work');
+
+    // 3. The factory must hand out a new client carrying the new grant.
+    const clientAfter = await sys.factory.getClient('work');
+    assert.notEqual(clientAfter, clientBefore, 'factory returned the superseded OAuth2Client');
+    assert.equal(clientAfter.credentials.access_token, NEW_ACCESS);
+
+    // 4. And the next tool call must rebuild its Drive service on that client
+    //    instead of reusing the one cached under this alias.
+    const after = await callTool(ctx.client, 'search', { query: 'q', account: 'work' });
+    assert.notEqual(after.isError, true, `post-reauth call errored: ${JSON.stringify(after)}`);
+    assert.ok(
+      driveAuths.length > 0,
+      'post-reauth call reused the cached Drive service instead of rebuilding it',
+    );
+    for (const auth of driveAuths) {
+      assert.notEqual(auth, clientBefore, 'Drive service was rebuilt on the superseded client');
+    }
+
+    // 5. The new grant is persisted, so a restart would agree with memory.
+    const onDisk = JSON.parse(await fs.readFile(tokenPath, 'utf8'));
+    assert.equal(onDisk.accounts.work.accessToken, NEW_ACCESS);
+    assert.equal(onDisk.accounts.work.email, 'work@example.com');
+  });
+});


### PR DESCRIPTION
Fixes #168.

## Problem

`manage_accounts add <existing-alias>` re-consents an account in place — to broaden scopes or recover a revoked grant. The new record was persisted correctly, but nothing dropped the clients built from the *old* grant:

- the per-alias `OAuth2Client` cached in `AccountClientFactory` (`src/auth/accountClientFactory.ts`), and
- the `drive`/`calendar` services cached in `_driveByAlias`/`_calendarByAlias` and pre-warmed for every tool call in `buildToolContext`.

So a Drive call right after a successful re-auth kept using the superseded tokens and failed with `Account '<alias>' authorization was revoked or has expired`, until the server was restarted. `removeAccountFlow` already evicted all three; the add path never got it. Team mode has the same wiring for its own factory (`onUserAuthorized: (sub) => clientFactory.evict(sub)`).

## Fix

Extract that eviction into `evictAccountClients(alias)` and call it from `addAccountFlow`'s `onTokens` right after `store.upsert(record)` (and from `removeAccountFlow`, unchanged behavior). The next call rebuilds from the record just written. The CLI `auth <alias>` path shares `addAccountFlow`, so it inherits the fix.

Scope is deliberately limited to the eviction the issue describes. Unrelated stale-state hygiene in the factory (`inflightRefresh`, late `'tokens'` write-backs from a refresh racing the consent window) is left alone.

## Test

New `test/integration/reauth-evicts-clients.test.ts` drives the real flow end to end: a real local-OAuth `AuthSystem` over a temp `tokens.json`, the real `AuthServer` answering a real HTTP `/oauth2callback`, with the code-for-tokens exchange stubbed — no network reaches Google. It asserts the factory hands out a *new* client carrying the new access token, that the next tool call rebuilds its Drive service rather than reusing the cached one, that the failed userinfo lookup doesn't regress the known email/sub, and that the new grant is on disk.

Verified it fails without the fix, and that each half is independently covered: disabling only the factory eviction trips assertion 3, disabling only the service-cache deletes trips assertion 4.

Reaching that flow needed two test-only exports alongside the existing `_*ForTesting` hooks — `_setAuthSystemForTesting` (the shared harness pins `mode: 'test'`, where `add` short-circuits in `requireLocalOAuthMode`) and `_addAccountFlowForTesting` (defaults `openBrowser` to false; `AuthServer.start(true)` would launch a real browser).

Also: a note on the `add` row in `docs/authentication.md`, and a `### Fixed` changelog entry under Unreleased. No version bump — this repo bumps in separate `chore: prepare release` commits.

`npm run lint` and `npm test` (816 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)