### PR TITLE
chore: prepare release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.6.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.5.1...v2.6.0) (2026-08-21)
+
+Makes Drive listings **ordered and self-describing**. `search` gains an `orderBy` and sorts most-recently-modified first by default instead of returning Drive's arbitrary order, `listGoogleDocs`/`listGoogleSheets` stop defaulting to *oldest* first, and all three name their effective ordering in the response — so a caller is told the list is sorted rather than left to work it out by comparing timestamps by eye. Also adds superscript/subscript (`baselineOffset`) to the Docs text-styling tools, on both the write and the formatted-read path. Additive — a new optional parameter on existing tools plus corrected default orderings, with no removed or renamed tools/parameters.
+
 ### Features
 
 - **drive:** `search` now sorts results and accepts an `orderBy` parameter. Results default to `modifiedTime desc` (most recently modified first) instead of Drive's unspecified default order, and the response header names the effective ordering (`Found N files (ordered by modifiedTime desc):`). Previously an unsorted, unlabeled result set left the caller to pick "the most recent" by comparing timestamps across up to 100 rows by eye — behind an LLM client that silently produced wrong answers, citing months-old files as the newest. `orderBy` accepts `modifiedTime desc`, `modifiedTime`, `createdTime desc`, `createdTime`, `recency desc`, `recency`, `name`, and `name_natural`; keys without `desc` sort ascending. When more results are available the response repeats the effective `orderBy` alongside the `pageToken`, so a follow-up page keeps the ordering instead of falling back to the default ([#167](https://github.com/piotr-agier/google-drive-mcp/issues/167))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.5.1",
+    "version": "2.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "2.5.1",
+            "version": "2.6.0",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.5.1",
+    "version": "2.6.0",
     "mcpName": "io.github.piotr-agier/google-drive-mcp",
     "description": "Secure access to Google Drive, Docs, Sheets, Slides, and Calendar through MCP.",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
         "id": "1028345101"
     },
     "websiteUrl": "https://github.com/piotr-agier/google-drive-mcp#readme",
-    "version": "2.5.1",
+    "version": "2.6.0",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "@piotr-agier/google-drive-mcp",
-            "version": "2.5.1",
+            "version": "2.6.0",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"


### PR DESCRIPTION
Cuts **2.6.0** for the work that landed after the `v2.5.1` tag: search ordering (#167 via #171 and #172) and Docs `baselineOffset` (#158).

## Version

**MINOR — 2.5.1 → 2.6.0.** Additive at the public contract: a new optional `orderBy` on `search`, a new `baselineOffset` on the Docs styling tools, and corrected default orderings on `search`/`listGoogleDocs`/`listGoogleSheets`. No removed or renamed tools or parameters. Consistent with the 2.5.0/2.4.0 precedent of reserving major for public-contract breaks.

The default-ordering change is visible to existing callers, but it is the bug fix #167 asked for — both changelog entries say so plainly.

## Changes

- `package.json` + `package-lock.json` → `2.6.0` (via `npm version --no-git-tag-version`).
- `CHANGELOG.md`: the `[Unreleased]` notes move into a dated `2.6.0` section with a compare link and a summary paragraph; the empty `[Unreleased]` header stays at the top, per the 2.5.0 precedent.
- `server.json` → `2.6.0` in **both** places (the server record and the npm package entry).

That last one is worth a look, since it is not in the 2.5.0 release-prep precedent — `server.json` postdates it, arriving with the MCP Registry work in 2.5.1. It is what the `publish-registry` job sends to the registry. Left at `2.5.1`, the release would have published npm `2.6.0` while `registry:verify` found the existing `2.5.1` record, reported "already published", and skipped the registry update — a silently stale registry record rather than a failed job.

## Verification

- `npm run lint` clean, `npm run build` clean, `npm test` → 824 pass / 0 fail.
- `npm run registry:validate` passes against the live registry for `io.github.piotr-agier/google-drive-mcp@2.6.0`.
- `npm run registry:verify` reports no `2.6.0` record yet, which is the exit-2 path the publish workflow keys off to actually publish.
- The `publish.yml` tag-vs-`package.json` guard will match on `v2.6.0`.

## After merge

This PR only prepares the release. Publishing still needs a GitHub Release published on tag **`v2.6.0`** against the merge commit — that is what triggers `publish.yml` (npm via OIDC, then the MCP Registry). I have not created the tag or the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
