### PR TITLE
docs(changelog): point compare links at tags that exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [2.6.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.5.1...v2.6.0) (2026-08-21)
+## [2.6.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.5.0...v2.6.0) (2026-08-21)
 
 Makes Drive listings **ordered and self-describing**. `search` gains an `orderBy` and sorts most-recently-modified first by default instead of returning Drive's arbitrary order, `listGoogleDocs`/`listGoogleSheets` stop defaulting to *oldest* first, and all three name their effective ordering in the response — so a caller is told the list is sorted rather than left to work it out by comparing timestamps by eye. Also adds superscript/subscript (`baselineOffset`) to the Docs text-styling tools, on both the write and the formatted-read path. Additive — a new optional parameter on existing tools plus corrected default orderings, with no removed or renamed tools/parameters.
 
@@ -19,7 +19,10 @@ Makes Drive listings **ordered and self-describing**. `search` gains an `orderBy
 - **auth:** re-authenticating an existing account with `manage_accounts add <alias>` now takes effect immediately instead of requiring a server restart. The refreshed grant was persisted correctly, but the OAuth client cached for that alias — and the Drive/Calendar services built on it — were left in place, so every subsequent call kept using the superseded (often revoked) grant and failed with "authorization was revoked or has expired". A completed re-consent now evicts those cached clients, the way removing an account already did ([#168](https://github.com/piotr-agier/google-drive-mcp/issues/168))
 - **docs:** `formatGoogleDocText` now advertises `baselineOffset` in its input schema. The alias shares a handler and validation schema with `applyTextStyle`, so the parameter already worked at runtime, but it was missing from the advertised tool definition — clients that build arguments from (or validate against) the published schema could not reach superscript/subscript through the alias
 
-## [2.5.1](https://github.com/piotr-agier/google-drive-mcp/compare/v2.5.0...v2.5.1) (2026-07-17)
+## 2.5.1 (2026-07-17)
+
+Prepared but never published — there is no `v2.5.1` tag or release, and npm went
+straight from 2.5.0 to 2.6.0. The changes below first shipped in 2.6.0.
 
 ### Distribution
 


### PR DESCRIPTION
Blocking the 2.6.0 release — found while about to tag it.

## Problem

**2.5.1 was prepared but never released.** There is no `v2.5.1` tag, no GitHub release for it, and npm's highest published version is `2.5.0`. `package.json`/`server.json` sat at 2.5.1 and the CHANGELOG has a dated `[2.5.1]` section, but the release was never cut.

So both compare links that reference `v2.5.1` resolve to a 404:

- `[2.6.0](…/compare/v2.5.1...v2.6.0)` — added by #173, would have shipped inside the 2.6.0 tag
- `[2.5.1](…/compare/v2.5.0...v2.5.1)` — pre-existing

## Change

- 2.6.0 now compares against `v2.5.0`, the last tag that exists. The link resolves, and it spans everything the release actually contains — including the 2.5.1 Registry work, which reaches npm for the first time in 2.6.0.
- The 2.5.1 heading drops its dead link and gains a line stating it was never published and that its changes first shipped in 2.6.0. A reader who sees 2.5.1 in the changelog and cannot find it on npm should not have to guess why.

CHANGELOG only — no code, no version change. 2.6.0 remains the right number; semver does not require contiguity.

## Next

Once this merges, `v2.6.0` gets tagged against the merge commit to trigger `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
