### PR TITLE
docs(changelog): list the Registry work under the release that shipped it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.6.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.5.0...v2.6.0) (2026-08-21)
 
-Makes Drive listings **ordered and self-describing**. `search` gains an `orderBy` and sorts most-recently-modified first by default instead of returning Drive's arbitrary order, `listGoogleDocs`/`listGoogleSheets` stop defaulting to *oldest* first, and all three name their effective ordering in the response — so a caller is told the list is sorted rather than left to work it out by comparing timestamps by eye. Also adds superscript/subscript (`baselineOffset`) to the Docs text-styling tools, on both the write and the formatted-read path. Additive — a new optional parameter on existing tools plus corrected default orderings, with no removed or renamed tools/parameters.
+Makes Drive listings **ordered and self-describing**. `search` gains an `orderBy` and sorts most-recently-modified first by default instead of returning Drive's arbitrary order, `listGoogleDocs`/`listGoogleSheets` stop defaulting to *oldest* first, and all three name their effective ordering in the response — so a caller is told the list is sorted rather than left to work it out by comparing timestamps by eye. Also adds superscript/subscript (`baselineOffset`) to the Docs text-styling tools, on both the write and the formatted-read path. Additive — a new optional parameter on existing tools plus corrected default orderings, with no removed or renamed tools/parameters. Also carries the MCP Registry publication work prepared as 2.5.1 but never released, which reaches npm for the first time here.
 
 ### Features
 
@@ -19,14 +19,14 @@ Makes Drive listings **ordered and self-describing**. `search` gains an `orderBy
 - **auth:** re-authenticating an existing account with `manage_accounts add <alias>` now takes effect immediately instead of requiring a server restart. The refreshed grant was persisted correctly, but the OAuth client cached for that alias — and the Drive/Calendar services built on it — were left in place, so every subsequent call kept using the superseded (often revoked) grant and failed with "authorization was revoked or has expired". A completed re-consent now evicts those cached clients, the way removing an account already did ([#168](https://github.com/piotr-agier/google-drive-mcp/issues/168))
 - **docs:** `formatGoogleDocText` now advertises `baselineOffset` in its input schema. The alias shares a handler and validation schema with `applyTextStyle`, so the parameter already worked at runtime, but it was missing from the advertised tool definition — clients that build arguments from (or validate against) the published schema could not reach superscript/subscript through the alias
 
-## 2.5.1 (2026-07-17)
-
-Prepared but never published — there is no `v2.5.1` tag or release, and npm went
-straight from 2.5.0 to 2.6.0. The changes below first shipped in 2.6.0.
-
 ### Distribution
 
-- Publish verified npm/stdio metadata to the official MCP Registry under `io.github.piotr-agier/google-drive-mcp`, with live schema validation and GitHub OIDC publication integrated into the release workflow.
+- Publish verified npm/stdio metadata to the official MCP Registry under `io.github.piotr-agier/google-drive-mcp`, with live schema validation and GitHub OIDC publication integrated into the release workflow. Prepared as 2.5.1 in July but never released, so it reaches npm for the first time in this release
+
+## 2.5.1 (2026-07-17)
+
+Prepared but never released — there is no `v2.5.1` tag or GitHub release, and npm went
+straight from 2.5.0 to 2.6.0. Its changes are listed under 2.6.0.
 
 ## [2.5.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.4.0...v2.5.0) (2026-07-15)
 


### PR DESCRIPTION
Follow-up to #174 and the v2.6.0 release.

## Problem

The `2.6.0` section lists only `### Features` and `### Fixed`. The MCP Registry publication work is not in it — it sits under a `2.5.1` heading that only points *forward* ("its changes are listed under 2.6.0").

But 2.5.1 was never released, so 2.5.0 is the last version anyone actually has. Upgrading to 2.6.0 delivers the Registry work, and a reader scanning "what is in 2.6.0" does not see it there.

## Change

- The `### Distribution` entry moves into the `2.6.0` section, with a clause noting it was prepared as 2.5.1 and reaches npm for the first time here.
- The summary paragraph names it, so the one-line version of the release is complete.
- The `2.5.1` heading keeps a two-line stub explaining the version gap and pointing at 2.6.0 for its contents — the trail stays, the content lives with the release that shipped it.

CHANGELOG only.

## Note

The published `v2.6.0` release notes already covered this under "Also shipping here", so this brings the CHANGELOG in line with them rather than the other way round. I will refresh the release notes to match once this merges.

The `v2.6.0` tag points at `d0c2128`, one commit before this, so the tagged snapshot of `CHANGELOG.md` keeps the old arrangement. Not worth re-tagging a published release over a doc edit — the file on `master` is what the GitHub and npm views render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
