### PR TITLE
fix(deps): upgrade Google API clients to gaxios 7 for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,11 @@
             "version": "2.6.0",
             "license": "MIT",
             "dependencies": {
-                "@google-cloud/local-auth": "^3.0.1",
                 "@modelcontextprotocol/sdk": "^1.24.0",
                 "@types/express": "^5.0.3",
                 "express": "^5.1.0",
-                "google-auth-library": "^9.15.0",
-                "googleapis": "^144.0.0",
+                "google-auth-library": "^10.2.0",
+                "googleapis": "^173.0.0",
                 "jszip": "^3.10.1",
                 "open": "^10.2.0",
                 "pdf-lib": "^1.17.1",
@@ -34,6 +33,9 @@
                 "eslint": "^9.39.3",
                 "shx": "^0.4.0",
                 "typescript": "^5.6.2"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -523,9 +525,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -597,9 +599,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -667,64 +669,6 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/@google-cloud/local-auth": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@google-cloud/local-auth/-/local-auth-3.0.1.tgz",
-            "integrity": "sha512-YJ3GFbksfHyEarbVHPSCzhKpjbnlAhdzg2SEf79l6ODukrSM1qUOqfopY232Xkw26huKSndyzmJz+A6b2WYn7Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "arrify": "^2.0.1",
-                "google-auth-library": "^9.0.0",
-                "open": "^7.0.3",
-                "server-destroy": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@google-cloud/local-auth/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@google-cloud/local-auth/node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@google-cloud/local-auth/node_modules/open": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0",
-                "is-wsl": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@hono/node-server": {
             "version": "1.19.11",
             "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
@@ -789,6 +733,23 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@modelcontextprotocol/sdk": {
             "version": "1.26.0",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
@@ -830,9 +791,9 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -905,6 +866,16 @@
             "license": "MIT",
             "dependencies": {
                 "pako": "^1.0.10"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@types/body-parser": {
@@ -1051,7 +1022,6 @@
             "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.0",
                 "@typescript-eslint/types": "8.56.0",
@@ -1196,9 +1166,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -1282,7 +1252,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1310,9 +1279,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1344,9 +1313,9 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -1365,11 +1334,22 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT"
         },
+        "node_modules/ansi-regex": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -1388,20 +1368,10 @@
             "dev": true,
             "license": "Python-2.0"
         },
-        "node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/base64-js": {
@@ -1458,10 +1428,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -1570,7 +1539,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -1583,7 +1551,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/concat-map": {
@@ -1668,6 +1635,15 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/debug": {
@@ -1757,6 +1733,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "license": "MIT"
+        },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1770,6 +1752,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
+        "node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "license": "MIT"
         },
         "node_modules/encodeurl": {
@@ -1888,7 +1876,6 @@
             "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -1974,9 +1961,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2237,7 +2224,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -2363,6 +2349,29 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2448,6 +2457,46 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "license": "MIT",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2476,46 +2525,31 @@
             }
         },
         "node_modules/gaxios": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+            "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "extend": "^3.0.2",
                 "https-proxy-agent": "^7.0.1",
-                "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.9",
-                "uuid": "^9.0.1"
+                "node-fetch": "^3.3.2"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/gaxios/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
+                "node": ">=18"
             }
         },
         "node_modules/gcp-metadata": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-            "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+            "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "gaxios": "^6.1.1",
-                "google-logging-utils": "^0.0.2",
+                "gaxios": "^7.0.0",
+                "google-logging-utils": "^1.0.0",
                 "json-bigint": "^1.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/get-intrinsic": {
@@ -2568,6 +2602,27 @@
                 "node": ">=6"
             }
         },
+        "node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2595,72 +2650,74 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "9.15.1",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-            "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+            "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "gaxios": "^6.1.1",
-                "gcp-metadata": "^6.1.0",
-                "gtoken": "^7.0.0",
+                "gaxios": "^7.1.4",
+                "gcp-metadata": "8.1.2",
+                "google-logging-utils": "1.1.3",
                 "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/google-logging-utils": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-            "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/googleapis": {
-            "version": "144.0.0",
-            "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
-            "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+            "version": "173.0.0",
+            "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-173.0.0.tgz",
+            "integrity": "sha512-xEJJYLZ4qeenVyfzispNfRjCe9bsv7CzBv5zYFLvScOze9snJ8S9W6hjQ729CWPQt5mvn/JrcRaCHzQiukt0ng==",
             "license": "Apache-2.0",
             "dependencies": {
-                "google-auth-library": "^9.0.0",
-                "googleapis-common": "^7.0.0"
+                "google-auth-library": "^10.2.0",
+                "googleapis-common": "^8.0.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/googleapis-common": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
-            "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.3.tgz",
+            "integrity": "sha512-7g1yzQKx0mmNTjiK0H9dJ8eqKqDBveES9vLHeg5neb3BMQy/d1oQefIMhIpOVT8a+f+LOcixMEdRbFIW/cQUJw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "extend": "^3.0.2",
-                "gaxios": "^6.0.3",
-                "google-auth-library": "^9.7.0",
+                "gaxios": "7.1.3",
+                "google-auth-library": "10.5.0",
+                "google-logging-utils": "1.1.3",
                 "qs": "^6.7.0",
-                "url-template": "^2.0.8",
-                "uuid": "^9.0.0"
+                "url-template": "^2.0.8"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18"
             }
         },
-        "node_modules/googleapis-common/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
+        "node_modules/googleapis-common/node_modules/gaxios": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+            "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2",
+                "rimraf": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/gopd": {
@@ -2673,19 +2730,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/gtoken": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-            "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-            "license": "MIT",
-            "dependencies": {
-                "gaxios": "^6.0.0",
-                "jws": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
         "node_modules/has-flag": {
@@ -2727,7 +2771,6 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
             "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -2782,9 +2825,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2899,6 +2942,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2946,18 +2998,6 @@
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
             "license": "MIT"
         },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-wsl": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
@@ -2984,6 +3024,21 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
         },
         "node_modules/jose": {
             "version": "6.1.3",
@@ -3132,6 +3187,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3215,7 +3276,6 @@
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
             "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.2"
@@ -3235,6 +3295,15 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/ms": {
@@ -3266,24 +3335,42 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
         "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
             "license": "MIT",
             "dependencies": {
-                "whatwg-url": "^5.0.0"
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
             },
             "engines": {
-                "node": "4.x || >=6.0.0"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/npm-run-path": {
@@ -3429,6 +3516,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "license": "BlueOak-1.0.0"
+        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -3483,6 +3576,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/path-to-regexp": {
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
@@ -3506,9 +3615,9 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3651,12 +3760,6 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "license": "MIT"
-        },
         "node_modules/rechoir": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -3720,6 +3823,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rimraf": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+            "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^10.3.7"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/router": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -3773,23 +3891,9 @@
             }
         },
         "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "license": "MIT"
         },
         "node_modules/safer-buffer": {
@@ -3852,12 +3956,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/server-destroy": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-            "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
-            "license": "ISC"
         },
         "node_modules/setimmediate": {
             "version": "1.0.5",
@@ -4025,11 +4123,101 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
+        "node_modules/string-width": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT"
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/strip-eof": {
             "version": "1.0.0",
@@ -4116,12 +4304,11 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4150,12 +4337,6 @@
             "engines": {
                 "node": ">=0.6"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
         },
         "node_modules/ts-api-utils": {
             "version": "2.4.0",
@@ -4209,7 +4390,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4277,20 +4457,13 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
             "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/which": {
@@ -4316,6 +4489,94 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/wrappy": {
@@ -4357,7 +4618,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -61,13 +61,18 @@
         "lint:types": "tsc --noEmit",
         "lint:eslint": "eslint src/"
     },
+    "engines": {
+        "node": ">=18"
+    },
+    "overrides": {
+        "google-auth-library": "$google-auth-library"
+    },
     "dependencies": {
-        "@google-cloud/local-auth": "^3.0.1",
         "@modelcontextprotocol/sdk": "^1.24.0",
         "@types/express": "^5.0.3",
         "express": "^5.1.0",
-        "google-auth-library": "^9.15.0",
-        "googleapis": "^144.0.0",
+        "google-auth-library": "^10.2.0",
+        "googleapis": "^173.0.0",
         "jszip": "^3.10.1",
         "open": "^10.2.0",
         "pdf-lib": "^1.17.1",

--- a/src/auth/externalAuth.ts
+++ b/src/auth/externalAuth.ts
@@ -2,6 +2,7 @@
 // External authentication modes: Service Account & pre-obtained OAuth tokens
 // ---------------------------------------------------------------------------
 
+import { readFileSync } from 'node:fs';
 import { OAuth2Client } from 'google-auth-library';
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
 import { resolveOAuthScopes } from './scopes.js';
@@ -99,6 +100,78 @@ export function buildServiceAccountAuthOptions(): GoogleAuthOptions {
 }
 
 /**
+ * Credential `type` values `GoogleAuth` accepts from a file pointed at by
+ * `GOOGLE_APPLICATION_CREDENTIALS`. It is the standard ADC variable, so it may
+ * legitimately hold more than a service-account key — e.g. the `authorized_user`
+ * file written by `gcloud auth application-default login`, or a workload-identity
+ * config. Validation below stays permissive about which of these it is.
+ */
+const ADC_CREDENTIAL_TYPES = new Set([
+  'service_account',
+  'authorized_user',
+  'external_account',
+  'external_account_authorized_user',
+  'impersonated_service_account',
+  'gdch_service_account',
+]);
+
+/**
+ * Fail fast on a malformed credentials file.
+ *
+ * google-auth-library v10 no longer rejects one: `getClient()` *resolves* with a
+ * credential-less JWT client when the file is unparseable or missing its fields
+ * (only an absent file throws). Without this guard the server would report
+ * "Service account authentication successful" while holding no credentials, and
+ * every later call would fail with a misleading `Method doesn't allow
+ * unregistered callers`. v9 surfaced this immediately, so this restores that.
+ *
+ * Read errors (ENOENT and friends) propagate untouched — they already name the
+ * path and are clear. Messages never include file contents: the file holds a
+ * private key.
+ */
+export function validateCredentialsFile(keyFile: string): void {
+  const raw = readFileSync(keyFile, 'utf-8');
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      `Credentials file at ${keyFile} is not valid JSON. ` +
+        'It may be truncated or corrupted; re-download the key file.',
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Credentials file at ${keyFile} must contain a JSON object.`);
+  }
+
+  const cred = parsed as { type?: unknown; client_email?: unknown; private_key?: unknown };
+  const type = typeof cred.type === 'string' ? cred.type : undefined;
+
+  if (type !== undefined && !ADC_CREDENTIAL_TYPES.has(type)) {
+    throw new Error(
+      `Credentials file at ${keyFile} has unrecognized type "${type}". ` +
+        `Expected one of: ${[...ADC_CREDENTIAL_TYPES].join(', ')}.`,
+    );
+  }
+
+  // Only service-account keys are checked field-by-field; the other ADC shapes
+  // carry different fields and are left to GoogleAuth.
+  if (type === 'service_account' || type === undefined) {
+    const missing = (['client_email', 'private_key'] as const).filter(
+      (f) => typeof cred[f] !== 'string' || !(cred[f] as string).trim(),
+    );
+    if (missing.length) {
+      throw new Error(
+        `Credentials file at ${keyFile} is missing required field(s): ${missing.join(', ')}. ` +
+          'A service account key needs both; re-download it from the Google Cloud console.',
+      );
+    }
+  }
+}
+
+/**
  * Create an authorized client from a service account JSON key file.
  * `GoogleAuth` handles JWT signing and token refresh automatically.
  */
@@ -109,6 +182,8 @@ export async function createServiceAccountAuth(): Promise<any> {
     `Using service account credentials from ${options.keyFile}` +
       (subject ? ` (impersonating ${subject} via domain-wide delegation)` : ''),
   );
+
+  validateCredentialsFile(options.keyFile as string);
 
   const auth = new GoogleAuth(options);
   const client = await auth.getClient();

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -594,8 +594,10 @@ async function executeBatchUpdate(ctx: ToolContext, documentId: string, requests
     return response.data;
   } catch (error: any) {
     ctx.log('Google Docs batchUpdate error:', error.message);
-    if (error.code === 404) throw new Error(`Document not found (ID: ${documentId})`);
-    if (error.code === 403) throw new Error(`Permission denied for document (ID: ${documentId})`);
+    // gaxios 7 only sets a numeric `code` for AIP-193-shaped errors; `status`
+    // is the reliable field. Keep `code` for gaxios-6-shaped callers/mocks.
+    if ((error.status ?? error.code) === 404) throw new Error(`Document not found (ID: ${documentId})`);
+    if ((error.status ?? error.code) === 403) throw new Error(`Permission denied for document (ID: ${documentId})`);
     throw new Error(`Google Docs API Error: ${error.message}`);
   }
 }
@@ -731,7 +733,7 @@ async function findTextRange(ctx: ToolContext, documentId: string, textToFind: s
     return null;
   } catch (error: any) {
     ctx.log('Error finding text in document:', error.message);
-    if (error.code === 404) throw new Error(`Document not found (ID: ${documentId})`);
+    if ((error.status ?? error.code) === 404) throw new Error(`Document not found (ID: ${documentId})`);
     throw new Error(`Failed to search document: ${error.message}`);
   }
 }

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -7,6 +7,7 @@ import { escapeDriveQuery, isTextMime, ALL_DRIVES_LIST_PARAMS, DRIVE_ORDER_BY_VA
 import { downloadTextContent, writeTextContent } from './text-content.js';
 import { uploadImageToDrive } from '../utils/driveImageUpload.js';
 import { withRetry } from '../utils/retry.js';
+import { getResponseHeader } from '../utils/streams.js';
 
 // ---------------------------------------------------------------------------
 // Helper functions
@@ -2702,7 +2703,7 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
         );
       }
 
-      const rawContentType = (resp.headers?.['content-type'] as string | undefined) || 'application/octet-stream';
+      const rawContentType = getResponseHeader(resp.headers, 'content-type') || 'application/octet-stream';
       const mimeType = rawContentType.split(';')[0].trim();
       const dataBase64 = buffer.toString('base64');
 

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -11,6 +11,7 @@ import type { ToolDefinition, ToolContext, ToolResult } from '../types.js';
 import { errorResponse } from '../types.js';
 import { escapeDriveQuery, getMimeTypeFromFilename, isTextMime, TEXT_MIME_TYPES, ALL_DRIVES_LIST_PARAMS, PARENT_SCOPED_LIST_PARAMS, DRIVE_ORDER_BY_VALUES } from '../utils.js';
 import { downloadTextContent } from './text-content.js';
+import { toNodeReadable } from '../utils/streams.js';
 import { downloadDriveFile, GOOGLE_WORKSPACE_EXPORT_FORMATS } from '../download-file.js';
 import { getSecureTokenPath } from '../auth/utils.js';
 import { SCOPE_ALIASES, SCOPE_PRESETS, resolveOAuthScopes, splitScopes } from '../auth/scopes.js';
@@ -1934,14 +1935,14 @@ export async function handleTool(
 
           // Fetch revision content from the export link using authenticated request
           const exportResponse = await ctx.authClient.request({ url: exportLinks[selectedMime], responseType: 'stream' });
-          revisionBody = exportResponse.data;
+          revisionBody = toNodeReadable(exportResponse.data);
         } else {
           // For binary files, download the revision content directly
           const revision = await ctx.getDrive().revisions.get(
             { fileId: data.fileId, revisionId: data.revisionId, alt: 'media' },
             { responseType: 'stream' },
           );
-          revisionBody = revision.data;
+          revisionBody = toNodeReadable(revision.data);
           uploadMimeType = fileMimeType || 'application/octet-stream';
         }
 

--- a/src/tools/text-content.ts
+++ b/src/tools/text-content.ts
@@ -1,4 +1,5 @@
 import type { drive_v3 } from 'googleapis';
+import { toNodeReadable } from '../utils/streams.js';
 
 // ---------------------------------------------------------------------------
 // Shared read/write helpers for raw text/* files in Drive.
@@ -23,7 +24,7 @@ export async function downloadTextContent(
 
   const chunks: Buffer[] = [];
   await new Promise<void>((resolve, reject) => {
-    (mediaResponse.data as NodeJS.ReadableStream)
+    toNodeReadable(mediaResponse.data)
       .on('data', (chunk: Buffer) => chunks.push(chunk))
       .on('end', () => resolve())
       .on('error', (err: Error) => reject(err));

--- a/src/utils/retry.core.js
+++ b/src/utils/retry.core.js
@@ -11,7 +11,16 @@
 // non-idempotent, and a 5xx after the request reached the server may mean it
 // was partially applied — retrying could double-apply edits.
 const RETRYABLE_STATUS = new Set([429, 503, 504]);
-const RETRYABLE_CODES = new Set(['ETIMEDOUT', 'ECONNRESET', 'ENOTFOUND', 'EAI_AGAIN']);
+// UND_ERR_CONNECT_TIMEOUT and UND_ERR_SOCKET are undici's (native fetch)
+// analogues of ETIMEDOUT-before-connect and ECONNRESET — same hazard profile.
+const RETRYABLE_CODES = new Set([
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
 const MAX_DELAY_MS = 30_000;
 
 export class TimeoutError extends Error {
@@ -31,12 +40,22 @@ function httpStatus(err) {
   return typeof s === 'number' ? s : undefined;
 }
 
+// gaxios 7 wraps native-fetch transport failures as GaxiosError(code:
+// undefined) -> cause: TypeError('fetch failed') -> cause: the undici error
+// carrying the real code, so the flat err.code check alone would miss every
+// transport error. The walk is depth-bounded to survive cyclic cause chains.
+function hasRetryableCode(err) {
+  for (let e = err, depth = 0; e && depth < 5; e = e.cause, depth++) {
+    if (typeof e.code === 'string' && RETRYABLE_CODES.has(e.code)) return true;
+  }
+  return false;
+}
+
 function isRetryable(err) {
   if (!err) return false;
   const status = httpStatus(err);
   if (status !== undefined && RETRYABLE_STATUS.has(status)) return true;
-  if (typeof err.code === 'string' && RETRYABLE_CODES.has(err.code)) return true;
-  return false;
+  return hasRetryableCode(err);
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/src/utils/streams.ts
+++ b/src/utils/streams.ts
@@ -1,0 +1,20 @@
+import { Readable } from 'node:stream';
+
+/**
+ * Normalize a media-download response body to a Node Readable.
+ *
+ * gaxios 7 (native fetch) returns a web ReadableStream for
+ * `responseType: 'stream'`, while older clients and test doubles produce Node
+ * Readables or already-buffered bodies (Buffer/string). Downstream code relies
+ * on Node stream semantics (`.on()` listeners, upload media bodies), so accept
+ * any of those shapes here.
+ */
+export function toNodeReadable(data: unknown): Readable {
+  if (data instanceof Readable) return data;
+  if (typeof data === 'string' || data instanceof Uint8Array) {
+    // Wrap in an array so Readable.from emits one chunk instead of iterating
+    // per character / per byte.
+    return Readable.from([data]);
+  }
+  return Readable.fromWeb(data as import('node:stream/web').ReadableStream);
+}

--- a/src/utils/streams.ts
+++ b/src/utils/streams.ts
@@ -18,3 +18,28 @@ export function toNodeReadable(data: unknown): Readable {
   }
   return Readable.fromWeb(data as import('node:stream/web').ReadableStream);
 }
+
+/**
+ * Read a single header from a gaxios response.
+ *
+ * gaxios 7 (native fetch) exposes `response.headers` as a `Headers` instance,
+ * where bracket access silently yields `undefined` — gaxios 6 handed back a
+ * plain object, so `headers['content-type']` used to work. Both shapes are
+ * accepted here so test doubles that pass plain objects keep working.
+ * Header names are case-insensitive in both.
+ */
+export function getResponseHeader(headers: unknown, name: string): string | undefined {
+  if (!headers) return undefined;
+
+  if (typeof (headers as Headers).get === 'function') {
+    return (headers as Headers).get(name) ?? undefined;
+  }
+
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+    if (key.toLowerCase() === lower) {
+      return typeof value === 'string' ? value : undefined;
+    }
+  }
+  return undefined;
+}

--- a/test/auth/log-redaction.test.ts
+++ b/test/auth/log-redaction.test.ts
@@ -37,6 +37,40 @@ function makeGaxiosError(): Error {
   return err;
 }
 
+/** A gaxios-7-shaped error: top-level numeric `status`, deep-copied config,
+ * and a native-fetch cause chain that also carries the request payload. */
+function makeGaxiosV7Error(): Error {
+  const undiciErr = Object.assign(new Error('socket hang up'), {
+    code: 'UND_ERR_SOCKET',
+    payload: `refresh_token=${SECRET_REFRESH_TOKEN}&client_secret=${SECRET_CLIENT_SECRET}`,
+  });
+  const fetchErr = new TypeError('fetch failed');
+  (fetchErr as Error & { cause?: unknown }).cause = undiciErr;
+  const err = new Error('Request failed with status code 500') as Error & {
+    status?: number;
+    config?: { url?: string; body?: string };
+    response?: { status?: number; data?: { error?: string; error_description?: string } };
+    cause?: unknown;
+  };
+  err.status = 500;
+  err.config = {
+    url: 'https://oauth2.googleapis.com/token',
+    body: `refresh_token=${SECRET_REFRESH_TOKEN}&client_secret=${SECRET_CLIENT_SECRET}&grant_type=refresh_token`,
+  };
+  err.response = { status: 500, data: { error: 'internal_failure' } };
+  err.cause = fetchErr;
+  return err;
+}
+
+test('describeErrorForLog drops the gaxios-7 config and cause chain', () => {
+  const rendered = describeErrorForLog(makeGaxiosV7Error());
+  assert.ok(!rendered.includes(SECRET_REFRESH_TOKEN));
+  assert.ok(!rendered.includes(SECRET_CLIENT_SECRET));
+  assert.match(rendered, /Request failed with status code 500/);
+  assert.match(rendered, /status=500/);
+  assert.match(rendered, /error=internal_failure/);
+});
+
 test('describeErrorForLog keeps safe fields and drops the gaxios request config', () => {
   const rendered = describeErrorForLog(makeGaxiosError());
   assert.ok(!rendered.includes(SECRET_REFRESH_TOKEN));

--- a/test/auth/refresh-round-trip.test.ts
+++ b/test/auth/refresh-round-trip.test.ts
@@ -236,3 +236,43 @@ test('factory surfaces invalid_grant as an actionable reconnect error (finding 5
     await cleanup();
   }
 });
+
+test('factory detects invalid_grant in the gaxios-7 error shape', async () => {
+  const { tokenPath, cleanup } = await setupTmpCredentials();
+  try {
+    const store = new AccountStore({ filePath: tokenPath, mode: 'local-oauth' });
+    await store.reload();
+    await store.upsert(makeRecord({ expiryDate: Date.now() + 3600_000 }));
+
+    const factory = new AccountClientFactory(store);
+    const client = await factory.getClient('work');
+
+    client.setCredentials({ ...client.credentials, expiry_date: Date.now() - 60_000 });
+    (client as unknown as { refreshAccessToken: () => Promise<never> }).refreshAccessToken =
+      async () => {
+        // gaxios 7 sets a top-level numeric `status` and still parses the
+        // OAuth error body into response.data.
+        const err = new Error('Request failed with status code 400') as Error & {
+          status?: number;
+          response?: { status?: number; data?: { error?: string; error_description?: string } };
+        };
+        err.status = 400;
+        err.response = {
+          status: 400,
+          data: { error: 'invalid_grant', error_description: 'Token has been expired or revoked.' },
+        };
+        throw err;
+      };
+
+    await assert.rejects(
+      () => factory.getClient('work'),
+      (err: Error) => {
+        assert.match(err.message, /revoked or has expired/);
+        assert.match(err.message, /manage_accounts add work/);
+        return true;
+      },
+    );
+  } finally {
+    await cleanup();
+  }
+});

--- a/test/download-file.test.ts
+++ b/test/download-file.test.ts
@@ -10,7 +10,7 @@ import { downloadDriveFile } from '../src/download-file.js';
 type MockDriveOptions = {
   mimeType: string;
   name: string;
-  streamFactory?: () => Readable;
+  streamFactory?: () => Readable | ReadableStream<Uint8Array>;
 };
 
 function createMockDrive(options: MockDriveOptions) {
@@ -123,6 +123,34 @@ test('uses extension-based export MIME for Workspace files', async () => {
     assert.equal(calls.lastExportMime, 'text/csv');
     assert.equal(result.exportMime, 'text/csv');
     assert.equal(readFileSync(outputPath, 'utf8'), 'payload');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('downloads a media response that is a web ReadableStream (gaxios 7 shape)', async () => {
+  const tempDir = createTempDir();
+  try {
+    const outputPath = join(tempDir, 'web-stream.txt');
+    const { drive } = createMockDrive({
+      mimeType: 'text/plain',
+      name: 'web-stream.txt',
+      streamFactory: () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('web-payload'));
+            controller.close();
+          },
+        }),
+    });
+
+    await downloadDriveFile(
+      drive,
+      { fileId: 'file-123', localPath: outputPath },
+      () => {}
+    );
+
+    assert.equal(readFileSync(outputPath, 'utf8'), 'web-payload');
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/external-auth.test.ts
+++ b/test/external-auth.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   isExternalTokenMode,
@@ -7,6 +10,7 @@ import {
   validateExternalTokenConfig,
   createExternalOAuth2Client,
   buildServiceAccountAuthOptions,
+  validateCredentialsFile,
   describeBypassedTokens,
 } from '../src/auth/externalAuth.js';
 import { SCOPE_ALIASES } from '../src/auth/scopes.js';
@@ -274,3 +278,100 @@ test('describeBypassedTokens tells the user to unset BOTH override vars when bot
     );
   },
 ));
+
+// ---------------------------------------------------------------------------
+// validateCredentialsFile
+//
+// google-auth-library v10 stopped rejecting malformed credentials files:
+// getClient() resolves with a credential-less JWT client, so the server would
+// claim "authentication successful" and then fail every call with a misleading
+// "unregistered callers" error. These pin the fail-fast guard that restores v9
+// behavior — and pin that it stays permissive toward non-service-account ADC
+// files, which GOOGLE_APPLICATION_CREDENTIALS may legitimately point at.
+// ---------------------------------------------------------------------------
+
+const PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nsuper-secret-key-material\n-----END PRIVATE KEY-----\n';
+
+function writeCredFile(contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gdrive-mcp-cred-'));
+  const file = join(dir, 'creds.json');
+  writeFileSync(file, contents);
+  return file;
+}
+
+test('validateCredentialsFile accepts a well-formed service account key', () => {
+  const file = writeCredFile(JSON.stringify({
+    type: 'service_account',
+    client_email: 'sa@example.iam.gserviceaccount.com',
+    private_key: PRIVATE_KEY,
+  }));
+  assert.doesNotThrow(() => validateCredentialsFile(file));
+});
+
+test('validateCredentialsFile rejects invalid JSON naming the file', () => {
+  const file = writeCredFile('{ this is not valid json ');
+  assert.throws(() => validateCredentialsFile(file), (err: Error) => {
+    assert.match(err.message, /not valid JSON/);
+    assert.ok(err.message.includes(file), 'error should name the offending file');
+    return true;
+  });
+});
+
+test('validateCredentialsFile rejects a service account key missing its fields', () => {
+  const file = writeCredFile(JSON.stringify({ type: 'service_account' }));
+  assert.throws(() => validateCredentialsFile(file), (err: Error) => {
+    assert.match(err.message, /client_email/);
+    assert.match(err.message, /private_key/);
+    return true;
+  });
+});
+
+test('validateCredentialsFile rejects a bare JSON object with no credential fields', () => {
+  const file = writeCredFile(JSON.stringify({ not: 'a valid sa key' }));
+  assert.throws(() => validateCredentialsFile(file), /missing required field/);
+});
+
+test('validateCredentialsFile rejects a non-object and an unknown type', () => {
+  assert.throws(() => validateCredentialsFile(writeCredFile('["array"]')), /must contain a JSON object/);
+  assert.throws(
+    () => validateCredentialsFile(writeCredFile(JSON.stringify({ type: 'not_a_real_type' }))),
+    /unrecognized type/,
+  );
+});
+
+test('validateCredentialsFile accepts non-service-account ADC credential types', () => {
+  // `gcloud auth application-default login` writes an authorized_user file;
+  // workload identity writes external_account. Neither carries client_email,
+  // and both are valid targets for GOOGLE_APPLICATION_CREDENTIALS.
+  const authorizedUser = writeCredFile(JSON.stringify({
+    type: 'authorized_user',
+    client_id: 'x.apps.googleusercontent.com',
+    client_secret: 'shh',
+    refresh_token: '1//token',
+  }));
+  assert.doesNotThrow(() => validateCredentialsFile(authorizedUser));
+
+  const externalAccount = writeCredFile(JSON.stringify({
+    type: 'external_account',
+    audience: '//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/x',
+    subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+    token_url: 'https://sts.googleapis.com/v1/token',
+  }));
+  assert.doesNotThrow(() => validateCredentialsFile(externalAccount));
+});
+
+test('validateCredentialsFile never echoes key material into the error', () => {
+  // The file holds a private key; a validation error must not leak it.
+  const file = writeCredFile(JSON.stringify({ type: 'service_account', private_key: PRIVATE_KEY }));
+  assert.throws(() => validateCredentialsFile(file), (err: Error) => {
+    assert.ok(!err.message.includes('super-secret-key-material'), 'key material leaked into error');
+    return true;
+  });
+});
+
+test('validateCredentialsFile lets a missing file surface as ENOENT', () => {
+  assert.throws(
+    () => validateCredentialsFile(join(tmpdir(), 'gdrive-mcp-definitely-missing.json')),
+    /ENOENT/,
+  );
+});

--- a/test/gaxios-contract.test.ts
+++ b/test/gaxios-contract.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { GoogleAuth, OAuth2Client } from 'google-auth-library';
+
+// ---------------------------------------------------------------------------
+// Contract tests for the HTTP client underneath googleapis / google-auth-library.
+//
+// Our code duck-types gaxios responses and errors (`res.data`, `res.headers`,
+// `err.status`, `err.code`) rather than importing its types, so `tsc` cannot
+// tell us when a dependency bump changes those shapes — the upgrade to gaxios 7
+// silently broke `getGoogleDocImage` exactly that way, and unit tests missed it
+// because their doubles were built in the *old* shape.
+//
+// These tests pin the real library's behavior against a local server (no
+// network, no credentials). When a future bump changes a shape, the failure
+// here names the assumption and the code that depends on it.
+// ---------------------------------------------------------------------------
+
+/** A local server standing in for a Google endpoint. */
+async function withServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+  run: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as { port: number };
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+/** An OAuth2Client is what tool code calls `.request()` on (`ctx.authClient`). */
+function client(): OAuth2Client {
+  const c = new OAuth2Client();
+  c.setCredentials({ access_token: 'test-token-not-a-secret' });
+  return c;
+}
+
+// ---------------------------------------------------------------------------
+// Response headers
+// ---------------------------------------------------------------------------
+test('response.headers is a Headers instance, so bracket access does NOT work', async () => {
+  await withServer(
+    (_req, res) => { res.writeHead(200, { 'content-type': 'image/png' }); res.end('bytes'); },
+    async (base) => {
+      const res = await client().request({ url: `${base}/img` });
+
+      // The contract src/utils/streams.ts#getResponseHeader exists to satisfy.
+      assert.equal(
+        typeof (res.headers as unknown as Headers).get, 'function',
+        'headers must expose the Headers API; getResponseHeader() relies on .get()',
+      );
+      assert.equal(
+        (res.headers as unknown as Record<string, unknown>)['content-type'], undefined,
+        'bracket access must stay unsupported — if this starts working, gaxios reverted to '
+        + 'plain-object headers and getResponseHeader() should be re-checked',
+      );
+      assert.equal((res.headers as unknown as Headers).get('content-type'), 'image/png');
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Stream responses
+// ---------------------------------------------------------------------------
+test('responseType "stream" yields a Node Readable (gaxios defaults to node-fetch v3, not native fetch)', async () => {
+  await withServer(
+    (_req, res) => { res.writeHead(200, { 'content-type': 'text/plain' }); res.end('payload'); },
+    async (base) => {
+      const res = await client().request({ url: `${base}/file`, responseType: 'stream' });
+
+      // gaxios returns `Response.body` verbatim. Its default fetch in Node is
+      // node-fetch v3, whose body is a Node stream — so `.on()` handlers work.
+      // Under *native* fetch this would be a web ReadableStream instead, which
+      // is why src/utils/streams.ts#toNodeReadable normalizes both. If this
+      // assertion ever fails, that helper stopped being merely defensive and is
+      // now load-bearing for every `responseType: 'stream'` caller.
+      assert.ok(
+        res.data instanceof Readable,
+        'expected a Node Readable; a web ReadableStream here means the fetch '
+        + 'implementation changed — audit every responseType:"stream" call site',
+      );
+      assert.equal(typeof (res.data as Readable).on, 'function');
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Error shapes — what isInvalidGrant() and retry.core.js read
+// ---------------------------------------------------------------------------
+test('an HTTP error exposes numeric status and a parsed JSON body', async () => {
+  await withServer(
+    (_req, res) => {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'invalid_grant', error_description: 'Token has been revoked.' }));
+    },
+    async (base) => {
+      await assert.rejects(
+        () => client().request({ url: `${base}/token`, method: 'POST' }),
+        (err: any) => {
+          // src/auth/accountClientFactory.ts#isInvalidGrant reads response.data.error
+          assert.equal(err.response?.data?.error, 'invalid_grant',
+            'isInvalidGrant() depends on the JSON body being parsed onto response.data');
+          // src/utils/retry.core.js#httpStatus reads response.status ?? status
+          assert.equal(err.status, 400, 'retry.core.js httpStatus() depends on a numeric top-level status');
+          assert.equal(err.response?.status, 400);
+          return true;
+        },
+      );
+    },
+  );
+});
+
+test('a transport failure exposes a string code (top level and in the cause chain)', async () => {
+  // Port 1 has nothing listening, so this fails before any HTTP exchange.
+  await assert.rejects(
+    () => client().request({ url: 'http://127.0.0.1:1/unreachable' }),
+    (err: any) => {
+      // retry.core.js#isRetryable walks the chain; today the code is already at
+      // the top, but the walk also covers wrappers that only set it on a cause.
+      const codes: unknown[] = [];
+      for (let e = err, depth = 0; e && depth < 5; e = e.cause, depth++) codes.push(e.code);
+      assert.ok(
+        codes.some((c) => typeof c === 'string' && c.length > 0),
+        `expected a string error code somewhere in the cause chain, got ${JSON.stringify(codes)}`,
+      );
+      assert.equal(err.status, undefined, 'a transport failure has no HTTP status');
+      return true;
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Credentials loading
+// ---------------------------------------------------------------------------
+test('GoogleAuth does NOT reject a malformed key file — validateCredentialsFile() must', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gdrive-mcp-contract-'));
+  const badKey = join(dir, 'bad.json');
+  writeFileSync(badKey, '{ truncated json ');
+
+  // google-auth-library v10 resolves a credential-less client here, where v9
+  // threw. That silent success is why src/auth/externalAuth.ts validates the
+  // file itself before constructing GoogleAuth. If this ever throws, upstream
+  // fixed it and our guard becomes belt-and-braces (still fine to keep).
+  const auth = new GoogleAuth({ keyFile: badKey, scopes: ['https://www.googleapis.com/auth/drive'] });
+  const resolved = await auth.getClient().then(() => true, () => false);
+  assert.equal(resolved, true,
+    'upstream behavior changed: GoogleAuth now rejects malformed key files — '
+    + 'revisit validateCredentialsFile() in src/auth/externalAuth.ts');
+});

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -2579,7 +2579,7 @@ describe('Docs tools', () => {
       let requestedUrl = '';
       ctx.setAuthRequest(async (opts: any) => {
         requestedUrl = opts.url;
-        return { data: pngArrayBuffer(), headers: { 'content-type': 'image/png' } };
+        return { data: pngArrayBuffer(), headers: new Headers({ 'content-type': 'image/png' }) };
       });
       const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
       assert.equal(res.isError, false);
@@ -2591,15 +2591,26 @@ describe('Docs tools', () => {
 
     it('strips charset from the content-type header', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
-      ctx.setAuthRequest(async () => ({ data: pngArrayBuffer(), headers: { 'content-type': 'image/jpeg; charset=binary' } }));
+      ctx.setAuthRequest(async () => ({ data: pngArrayBuffer(), headers: new Headers({ 'content-type': 'image/jpeg; charset=binary' }) }));
       const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
       assert.equal(res.isError, false);
       assert.equal(res.content[0].mimeType, 'image/jpeg');
     });
 
+    // gaxios 7 returns a Headers instance (see test/gaxios-contract.test.ts); the
+    // doubles above use it. This one keeps the legacy plain-object shape covered,
+    // since getResponseHeader() accepts both.
+    it('reads a plain-object content-type header (pre-gaxios-7 shape)', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
+      ctx.setAuthRequest(async () => ({ data: pngArrayBuffer(), headers: { 'content-type': 'image/gif' } }));
+      const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
+      assert.equal(res.isError, false);
+      assert.equal(res.content[0].mimeType, 'image/gif');
+    });
+
     it('returns a base64 JSON envelope when outputFormat=base64', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
-      ctx.setAuthRequest(async () => ({ data: pngArrayBuffer(), headers: { 'content-type': 'image/png' } }));
+      ctx.setAuthRequest(async () => ({ data: pngArrayBuffer(), headers: new Headers({ 'content-type': 'image/png' }) }));
       const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1', outputFormat: 'base64' });
       assert.equal(res.isError, false);
       assert.equal(res.content[0].type, 'text');
@@ -2635,7 +2646,7 @@ describe('Docs tools', () => {
       let requestedUrl = '';
       ctx.setAuthRequest(async (opts: any) => {
         requestedUrl = opts.url;
-        return { data: pngArrayBuffer(), headers: { 'content-type': 'image/png' } };
+        return { data: pngArrayBuffer(), headers: new Headers({ 'content-type': 'image/png' }) };
       });
       const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-2' });
       assert.equal(res.isError, false);
@@ -2688,7 +2699,7 @@ describe('Docs tools', () => {
     it('reports a non-contradictory decimal size when the image exceeds the 40 MB cap', async () => {
       ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: imageDocData }));
       const oversized = new Uint8Array(42257613).buffer; // ~40.3 MB, just over the 40 MB cap
-      ctx.setAuthRequest(async () => ({ data: oversized, headers: { 'content-type': 'image/png' } }));
+      ctx.setAuthRequest(async () => ({ data: oversized, headers: new Headers({ 'content-type': 'image/png' }) }));
       const res = await callTool(ctx.client, 'getGoogleDocImage', { documentId: 'doc-1', inlineObjectId: 'obj-1' });
       assert.equal(res.isError, true);
       const text = res.content[0].text!;

--- a/test/integration/drive.test.ts
+++ b/test/integration/drive.test.ts
@@ -323,6 +323,23 @@ describe('Drive tools', () => {
       assert.ok(text.endsWith('Hello World'));
     });
 
+    it('reads content delivered as a web ReadableStream (gaxios 7 shape)', async () => {
+      ctx.mocks.drive.service.files.get._setImpl(async (p: any) =>
+        p?.alt === 'media'
+          ? {
+              data: new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode('Hello Web'));
+                  controller.close();
+                },
+              }),
+            }
+          : { data: { id: 'file-1', name: 'notes.txt', mimeType: 'text/plain', parents: ['root'] } });
+      const res = await callTool(ctx.client, 'readTextFile', { fileId: 'file-1' });
+      assert.equal(res.isError, false);
+      assert.ok(res.content[0].text!.endsWith('Hello Web'));
+    });
+
     it('reports code-point Length for astral characters (emoji counts as 1)', async () => {
       stubTextFile('😀😀😀');
       const res = await callTool(ctx.client, 'readTextFile', { fileId: 'file-1' });

--- a/test/integration/team-dispatch.test.ts
+++ b/test/integration/team-dispatch.test.ts
@@ -395,8 +395,13 @@ describe('Team mode — bearer-guarded per-user dispatch', () => {
     client.setCredentials({ ...client.credentials, expiry_date: Date.now() - 60_000 });
     (client as unknown as { refreshAccessToken: () => Promise<never> }).refreshAccessToken =
       async () => {
-        const err = new Error('invalid_grant') as Error & { response?: { data?: { error?: string } } };
-        err.response = { data: { error: 'invalid_grant' } };
+        // gaxios-7-realistic shape: top-level `status` plus the parsed body.
+        const err = new Error('invalid_grant') as Error & {
+          status?: number;
+          response?: { status?: number; data?: { error?: string } };
+        };
+        err.status = 400;
+        err.response = { status: 400, data: { error: 'invalid_grant' } };
         throw err;
       };
 

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -51,6 +51,49 @@ test('retries on numeric err.status and on string err.code', async () => {
   assert.equal(calls, 3);
 });
 
+// gaxios 7 (native fetch) wraps transport failures as GaxiosError(code:
+// undefined) -> cause: TypeError('fetch failed') -> cause: undici error with
+// the real code. The retry policy must find retryable codes down that chain.
+const fetchFailedErr = (code: string) => {
+  const undiciErr = Object.assign(new Error('socket hang up'), { code });
+  const fetchErr = new TypeError('fetch failed');
+  (fetchErr as Error & { cause?: unknown }).cause = undiciErr;
+  return Object.assign(new Error('Request failed'), { cause: fetchErr });
+};
+
+test('retries a gaxios-7 transport error with the code nested in err.cause.cause', async () => {
+  for (const code of ['ECONNRESET', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_SOCKET']) {
+    let calls = 0;
+    const out = await withRetry(async () => {
+      calls++;
+      if (calls === 1) throw fetchFailedErr(code);
+      return 'ok';
+    }, cfg({ retryMax: 2 }));
+    assert.equal(out, 'ok');
+    assert.equal(calls, 2, `expected one retry for nested code ${code}`);
+  }
+});
+
+test('does not retry a non-retryable code nested in the cause chain', async () => {
+  let calls = 0;
+  await assert.rejects(
+    withRetry(async () => { calls++; throw fetchFailedErr('ECONNREFUSED'); }, cfg({ retryMax: 3 })),
+    /Request failed/,
+  );
+  assert.equal(calls, 1);
+});
+
+test('cause-chain walk is bounded on a cyclic cause chain', async () => {
+  const cyclic = new Error('cyclic') as Error & { cause?: unknown };
+  cyclic.cause = cyclic;
+  let calls = 0;
+  await assert.rejects(
+    withRetry(async () => { calls++; throw cyclic; }, cfg({ retryMax: 3 })),
+    /cyclic/,
+  );
+  assert.equal(calls, 1);
+});
+
 test('exhausts retryMax then throws the last error', async () => {
   let calls = 0;
   await assert.rejects(

--- a/test/streams.test.ts
+++ b/test/streams.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+import test from 'node:test';
+
+import { toNodeReadable } from '../src/utils/streams.js';
+
+async function collect(stream: Readable): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+test('toNodeReadable passes a Node Readable through unchanged', async () => {
+  const source = Readable.from(['node-', 'payload']);
+  const out = toNodeReadable(source);
+  assert.equal(out, source);
+  assert.equal(await collect(out), 'node-payload');
+});
+
+test('toNodeReadable wraps buffered bodies as a single chunk', async () => {
+  assert.equal(await collect(toNodeReadable(Buffer.from('buffer-payload'))), 'buffer-payload');
+  assert.equal(await collect(toNodeReadable('string-payload')), 'string-payload');
+});
+
+test('toNodeReadable converts a web ReadableStream to a Node Readable', async () => {
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('web-'));
+      controller.enqueue(new TextEncoder().encode('payload'));
+      controller.close();
+    },
+  });
+  const out = toNodeReadable(source);
+  assert.ok(out instanceof Readable);
+  assert.equal(await collect(out), 'web-payload');
+});

--- a/test/streams.test.ts
+++ b/test/streams.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { Readable } from 'node:stream';
 import test from 'node:test';
 
-import { toNodeReadable } from '../src/utils/streams.js';
+import { toNodeReadable, getResponseHeader } from '../src/utils/streams.js';
 
 async function collect(stream: Readable): Promise<string> {
   const chunks: Buffer[] = [];
@@ -35,4 +35,32 @@ test('toNodeReadable converts a web ReadableStream to a Node Readable', async ()
   const out = toNodeReadable(source);
   assert.ok(out instanceof Readable);
   assert.equal(await collect(out), 'web-payload');
+});
+
+// ---------------------------------------------------------------------------
+// getResponseHeader
+//
+// gaxios 7 returns a `Headers` instance where gaxios 6 returned a plain object,
+// so `headers['content-type']` silently became undefined — which made
+// getGoogleDocImage label every image application/octet-stream.
+// ---------------------------------------------------------------------------
+
+test('getResponseHeader reads from a gaxios-7 Headers instance', () => {
+  const h = new Headers({ 'content-type': 'image/png' });
+  assert.equal(getResponseHeader(h, 'content-type'), 'image/png');
+  assert.equal(getResponseHeader(h, 'Content-Type'), 'image/png', 'must be case-insensitive');
+  assert.equal(getResponseHeader(h, 'x-absent'), undefined);
+});
+
+test('getResponseHeader still reads a gaxios-6 style plain object', () => {
+  const h = { 'content-type': 'image/jpeg' };
+  assert.equal(getResponseHeader(h, 'content-type'), 'image/jpeg');
+  assert.equal(getResponseHeader(h, 'CONTENT-TYPE'), 'image/jpeg', 'must be case-insensitive');
+  assert.equal(getResponseHeader(h, 'x-absent'), undefined);
+});
+
+test('getResponseHeader handles missing/!string headers without throwing', () => {
+  assert.equal(getResponseHeader(undefined, 'content-type'), undefined);
+  assert.equal(getResponseHeader(null, 'content-type'), undefined);
+  assert.equal(getResponseHeader({ 'content-type': 12345 }, 'content-type'), undefined);
 });


### PR DESCRIPTION
## Summary

Fixes #166 — on Node 24, OAuth token refresh failed with `Invalid response body while trying to fetch https://oauth2.googleapis.com/token: Premature close`. The cause is `gaxios@6` → `node-fetch@2`, which misbehaves against Google's token endpoint under Node 24. gaxios 7 ships `node-fetch@3` instead and is unaffected.

Verified live on Node 24 (see the verification comment below): the transport now returns a structured HTTP response where gaxios 6 gave "Premature close", and a forced token refresh through the server succeeds.

### Dependency changes
- Removed `@google-cloud/local-auth` — unused (zero imports), and the only thing pinning `google-auth-library@^9`.
- `google-auth-library@^10.2.0`, `googleapis@^173.0.0` (resolve to 10.9.1 / 173.0.0, gaxios 7).
- Added an npm `overrides` entry for `google-auth-library`: `googleapis-common@8` pins an **exact** version, which otherwise nests a duplicate copy and breaks `tsc` with mismatched `OAuth2Client` types.
- `node-fetch@2` is gone from the tree entirely (the remaining `node-fetch@3` is what gaxios 7 itself uses).
- Added `"engines": { "node": ">=18" }`, matching the upstream floor.

### Two regressions this upgrade introduced, found by live testing and fixed here

**1. Malformed service-account key files were silently accepted** (`97a676a`). In google-auth-library v10, `new GoogleAuth({keyFile}).getClient()` *resolves* with a credential-less JWT client when the file is unparseable or missing fields — only an absent file still throws. The server therefore logged `Service account authentication successful` while holding no credentials, and every later call failed with a misleading `Method doesn't allow unregistered callers`. v9 failed immediately. `validateCredentialsFile()` now runs before `GoogleAuth` is constructed, naming the file and the missing fields and never echoing key material. `GOOGLE_APPLICATION_CREDENTIALS` is the standard ADC variable, so non-service-account types (`authorized_user`, `external_account`, …) are deliberately still accepted; only `service_account` keys are checked field-by-field, and a missing file still surfaces as `ENOENT`.

**2. Every image was mislabelled `application/octet-stream`** (`3504826`). gaxios 7 exposes `response.headers` as a `Headers` instance where v6 returned a plain object, so `getGoogleDocImage`'s bracket-access content-type lookup always fell through to its default — including in the MCP `type: "image"` block clients use to render. `getResponseHeader()` accepts both shapes case-insensitively. This was the only gaxios response-header read in the codebase. Verified live: an inline PNG now reports `image/png`.

### Defensive adaptations (not fixes for observed breakage)

gaxios 7's README describes native-fetch semantics, but `Gaxios.#getFetch()` resolves to node-fetch v3 whenever `window` is undefined — so on Node the old shapes largely persist. Measured rather than assumed:

- **`responseType: 'stream'` still yields a Node `Readable`** (a `PassThrough`), confirmed against the live Drive API. `toNodeReadable()` normalizes web `ReadableStream`s too, so the `.on()` reader in `downloadTextContent` and the `restoreRevision` download→upload round trip stay correct if the default changes or a caller supplies its own `fetchImplementation`.
- **Transport errors still carry a top-level string `code`** (`ECONNREFUSED` observed), so the previous flat check kept working. The retry policy now walks the cause chain anyway, which also covers wrappers that only set a code on a cause, and accepts undici's `UND_ERR_CONNECT_TIMEOUT` / `UND_ERR_SOCKET`.
- `docs.ts` 404/403 mapping prefers the v7 top-level numeric `error.status`; v7 sets a numeric `code` only for AIP-193-shaped errors.
- No change needed, verified: `isInvalidGrant` (`response.data.error` survives), `describeErrorForLog` (allowlist reads only preserved fields), upload bodies (Node `Readable` still accepted), the three `responseType: 'arraybuffer'` sites (`Buffer.from` accepts both), AbortSignal forwarding.

### CI
Matrix now runs Node **22 and 24** — Node 24 is where #166 reproduces and was previously untested.

### Tests (834 → 851)
The image regression survived 834 passing tests because the doubles were built in the gaxios 6 shape: `getGoogleDocImage` already asserted `mimeType === 'image/png'`, but its mock returned `headers` as a plain object. Right assertion, wrong fixture.

`test/gaxios-contract.test.ts` (`479e0e2`) now pins the real library's shapes against a local HTTP server — no network, no credentials — without importing gaxios types: `Headers`-instance headers, Node-Readable stream bodies, numeric `status` with parsed `response.data`, a string `code` in the transport-error cause chain, and `GoogleAuth`'s acceptance of a malformed key file. Each failure message names the assumption and the source file that depends on it. The `getGoogleDocImage` doubles now use `new Headers(...)` — reintroducing the bug fails them, verified — with one plain-object case kept for the back-compat branch. Plus unit tests for `validateCredentialsFile`, `getResponseHeader`, `toNodeReadable`, and the retry cause-chain walk.

## Verification

- `npm run lint`, `npm run build`, `npm test` — 851/851 pass; CI green on Node 22 and 24.
- `npm ls google-auth-library gaxios node-fetch` — single deduped `google-auth-library@10.9.1`, gaxios 7 only, no `node-fetch@2`.
- **Live on Node 24** against real Google APIs: the #166 repro at transport and server level; `readTextFile`, both `restoreRevision` branches, `downloadFile` (binary + Workspace export → valid PDF), `uploadFile` create and in-place; all four auth modes (local OAuth, external token, full external set exercising its own refresh path, service account with a throwaway SA); and an HTTP-transport round trip with session isolation and clean SIGINT/SIGTERM shutdown. No "Premature close" in any run.
- Not covered: team mode (automated tests only), domain-wide delegation (needs a Workspace domain), and the Docker rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)