### PR TITLE
fix(team): attribute team logs by email and fix logWithUser payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **team:** log lines now name the acting user. Team-mode dispatch, session lifecycle (created / idle timeout / closed), sign-in callback, and per-user tool logs carry the member's Google `sub` and email, so an audit can tell who did what without joining an opaque `sub` against the team store. Error payloads passed to the per-user logger are rendered through the existing redaction helper instead of `JSON.stringify` (which turns an `Error` into `{}` and would serialize a gaxios error's raw request config). Single-user logs are unchanged ([#177](https://github.com/piotr-agier/google-drive-mcp/pull/177))
+
 ## [2.6.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.5.0...v2.6.0) (2026-08-21)
 
 Makes Drive listings **ordered and self-describing**. `search` gains an `orderBy` and sorts most-recently-modified first by default instead of returning Drive's arbitrary order, `listGoogleDocs`/`listGoogleSheets` stop defaulting to *oldest* first, and all three name their effective ordering in the response — so a caller is told the list is sorted rather than left to work it out by comparing timestamps by eye. Also adds superscript/subscript (`baselineOffset`) to the Docs text-styling tools, on both the write and the formatted-read path. Additive — a new optional parameter on existing tools plus corrected default orderings, with no removed or renamed tools/parameters. Also carries the MCP Registry publication work prepared as 2.5.1 but never released, which reaches npm for the first time here.

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,14 +89,20 @@ function log(message: string, data?: any) {
 }
 
 /** ctx.log for team mode — always attributes the log to the acting user by
- * merging `userId` into the data payload. Non-plain-object payloads (Error,
- * array, string) are wrapped so the userId is never lost. */
-function logWithUser(userId: string): (message: string, data?: any) => void {
+ * merging `userId` (the Google sub) and, when known, `email` into the data
+ * payload. Non-plain-object payloads (array, string, number) are wrapped so
+ * the attribution is never lost. Errors are rendered via describeErrorForLog:
+ * JSON.stringify(new Error(...)) is `{}` (message lost), and a raw gaxios
+ * error's enumerable request config can carry token material. */
+function logWithUser(userId: string, email?: string): (message: string, data?: any) => void {
+  const who = email ? { userId, email } : { userId };
   return (message: string, data?: any) => {
-    if (data && typeof data === 'object' && !Array.isArray(data) && !(data instanceof Error)) {
-      log(message, { ...data, userId });
+    if (data instanceof Error) {
+      log(message, { error: describeErrorForLog(data), ...who });
+    } else if (data && typeof data === 'object' && !Array.isArray(data)) {
+      log(message, { ...data, ...who });
     } else {
-      log(message, { data: data === undefined ? undefined : data, userId });
+      log(message, { data, ...who });
     }
   };
 }
@@ -559,20 +565,18 @@ async function buildToolContext(
     noAccount();
   }
 
-  const ctxLogger = account ? logWithUser(account.alias) : log;
   return {
     authClient,
     google,
     getDrive: () => drive ?? noAccount(),
     getCalendar: () => calendar ?? noAccount(),
-    log: ctxLogger,
+    log,
     resolvePath: (pathStr) => (drive ? resolvePath(pathStr, drive) : noAccount()),
     resolveFolderId: (input) => (drive ? resolveFolderId(input, drive) : noAccount()),
     checkFileExists: (name, parentFolderId) =>
       drive ? checkFileExists(name, parentFolderId, drive) : noAccount(),
     validateTextFileExtension,
     runtimeConfig,
-    userId: account?.alias,
 
     // Multi-account surface
     sessionId,
@@ -615,7 +619,9 @@ async function handleTeamToolCall(
 ): Promise<ToolResult> {
   const runtime = teamRuntime!;
   const sub = extra?.authInfo?.extra?.sub;
-  log('Handling tool request (team)', { tool: toolName, sub });
+  const rawEmail = extra?.authInfo?.extra?.email;
+  const email = typeof rawEmail === 'string' ? rawEmail : undefined;
+  log('Handling tool request (team)', { tool: toolName, sub, email });
   try {
     if (typeof sub !== 'string' || sub.length === 0) {
       // requireBearerAuth guarantees an identity on every /mcp request;
@@ -673,14 +679,14 @@ async function handleTeamToolCall(
     }
 
     const sessionId = extra?.sessionId ?? STDIO_SESSION_ID;
-    const ctx = await buildTeamToolContext(sessionId, sub);
+    const ctx = await buildTeamToolContext(sessionId, sub, email);
     for (const mod of domainModules) {
       const result = await mod.handleTool(toolName, rawArgs, ctx);
       if (result !== null) return result;
     }
     return errorResponse('Tool not found');
   } catch (error) {
-    log('Error in team tool request handler', { error: (error as Error).message });
+    log('Error in team tool request handler', { error: (error as Error).message, sub, email });
     return errorResponse((error as Error).message);
   }
 }
@@ -690,7 +696,11 @@ async function handleTeamToolCall(
  * per-sub TeamClientFactory, and the multi-account surface is stubbed to fail
  * loudly — in team mode there is exactly one identity per request.
  */
-async function buildTeamToolContext(sessionId: string, sub: string): Promise<ToolContext> {
+async function buildTeamToolContext(
+  sessionId: string,
+  sub: string,
+  email?: string,
+): Promise<ToolContext> {
   const runtime = teamRuntime!;
   const drive = await runtime.clientFactory.getDrive(sub);
   const calendar = await runtime.clientFactory.getCalendar(sub);
@@ -705,7 +715,7 @@ async function buildTeamToolContext(sessionId: string, sub: string): Promise<Too
     google,
     getDrive: () => drive,
     getCalendar: () => calendar,
-    log: logWithUser(sub),
+    log: logWithUser(sub, email),
     resolvePath: (pathStr) => resolvePath(pathStr, drive),
     resolveFolderId: (input) => resolveFolderId(input, drive),
     checkFileExists: (name, parentFolderId) => checkFileExists(name, parentFolderId, drive),
@@ -1266,6 +1276,9 @@ interface HttpSession {
   /** Team mode: the Google sub the session was initialized by. Every later
    * request must present a bearer for the same user (session hijack guard). */
   sub?: string;
+  /** Team mode: that user's email at session creation. Log attribution only —
+   * authorization always binds to `sub`. */
+  email?: string;
 }
 
 /**
@@ -1341,7 +1354,10 @@ function createHttpApp(host: string, options?: CreateHttpAppOptions) {
     sessionTimers.set(sid, setTimeout(async () => {
       const session = sessions.get(sid);
       if (session) {
-        log(`Session idle timeout: ${sid}`, session.sub ? { sub: session.sub } : undefined);
+        log(
+          `Session idle timeout: ${sid}`,
+          session.sub ? { sub: session.sub, email: session.email } : undefined,
+        );
         await session.transport.close();
         await session.server.close();
         sessions.delete(sid);
@@ -1402,11 +1418,14 @@ function createHttpApp(host: string, options?: CreateHttpAppOptions) {
       transport.onclose = () => {
         const sid = transport.sessionId;
         if (sid) {
-          const closedSub = sessions.get(sid)?.sub;
+          const closed = sessions.get(sid);
           clearSessionTimer(sid);
           sessions.delete(sid);
           if (authSystem) authSystem.sessions.delete(sid);
-          log(`Session closed: ${sid}`, closedSub ? { sub: closedSub } : undefined);
+          log(
+            `Session closed: ${sid}`,
+            closed?.sub ? { sub: closed.sub, email: closed.email } : undefined,
+          );
         }
       };
 
@@ -1415,14 +1434,19 @@ function createHttpApp(host: string, options?: CreateHttpAppOptions) {
       const sid = transport.sessionId;
       if (sid) {
         const sessionSub = teamAuth ? (req.auth?.extra?.sub as string | undefined) : undefined;
+        const sessionEmail = teamAuth ? (req.auth?.extra?.email as string | undefined) : undefined;
         sessions.set(sid, {
           transport,
           server: sessionServer,
           sub: sessionSub,
+          email: sessionEmail,
         });
         resetSessionTimer(sid);
         if (authSystem) authSystem.sessions.getOrCreate(sid);
-        log(`New session created: ${sid}`, sessionSub ? { sub: sessionSub } : undefined);
+        log(
+          `New session created: ${sid}`,
+          sessionSub ? { sub: sessionSub, email: sessionEmail } : undefined,
+        );
       }
     } catch (error) {
       log('Error handling POST /mcp', { error: (error as Error).message });

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,9 @@ export interface ToolContext {
 
   /** Stable user identity for the currently acting principal. Team mode sets
    * this to the bearer's Google `sub`. Single-user mode leaves it undefined
-   * (one local account, no per-user ID). Intended for log attribution. */
+   * (one local account, no per-user ID). Intended for log attribution; the
+   * human-readable email is stamped onto payloads by `ctx.log` itself rather
+   * than stored here. */
   userId?: string;
 
   // Multi-account surface (Phase 1: present on context but not yet consumed by tool

--- a/test/integration/team-dispatch.test.ts
+++ b/test/integration/team-dispatch.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { after, before, describe, it, mock } from 'node:test';
 import { createHash, randomBytes } from 'node:crypto';
 import type { Server as HttpServer } from 'node:http';
 import { google } from 'googleapis';
@@ -285,6 +285,35 @@ describe('Team mode — bearer-guarded per-user dispatch', () => {
     // Cached per sub: a second call builds no new drive client.
     await (await mcpPost(alice, aliceSid, toolsCall('search', { query: 'again' }, 3))).text();
     assert.equal(driveAuths.length, 2);
+  });
+
+  it('attributes dispatch and session logs to the acting user (sub + email)', async () => {
+    const bearer = await signIn({ sub: 'sub-carol', email: 'carol@corp.example', scope: DRIVE_SCOPE });
+    // log() writes through console.error; capture it around a session + call.
+    const errMock = mock.method(console, 'error', () => {});
+    try {
+      const sid = await initSession(bearer);
+      await (await mcpPost(bearer, sid, toolsCall('search', { query: 'audit' }))).text();
+      const lines = errMock.mock.calls.map((c) => c.arguments.join(' '));
+
+      const created = lines.find((l) => l.includes('New session created'));
+      assert.ok(created, 'session creation is logged');
+      assert.ok(
+        created!.includes('"sub":"sub-carol"') && created!.includes('"email":"carol@corp.example"'),
+        `session line names the user (got: ${created})`,
+      );
+
+      const dispatch = lines.find(
+        (l) => l.includes('Handling tool request (team)') && l.includes('"tool":"search"'),
+      );
+      assert.ok(dispatch, 'team dispatch is logged');
+      assert.ok(
+        dispatch!.includes('"sub":"sub-carol"') && dispatch!.includes('"email":"carol@corp.example"'),
+        `dispatch line names the user (got: ${dispatch})`,
+      );
+    } finally {
+      errMock.mock.restore();
+    }
   });
 
   it('rejects the account argument and manage_accounts outright', async () => {


### PR DESCRIPTION
Follow-up to #177 addressing the review findings.

## What changed

- **Email everywhere the sub is logged.** Bearer verification already puts `{ sub, email }` on `authInfo.extra`, so the team dispatch line, the dispatch error line, and all three session lifecycle lines (created / idle timeout / closed) now carry both. `buildTeamToolContext` threads the email into the per-user logger, so `ctx.log` payloads name the user too. An auditor reads `carol@corp.example` instead of joining a 21-digit `sub` against the team store.
- **`logWithUser` payload fixes.** `JSON.stringify(new Error(...))` is `{}`, so Error payloads lost their message; they now render through the existing `describeErrorForLog` redaction helper, which also keeps a gaxios error's raw request config (potentially carrying token material) out of the logs. The no-op `data === undefined ? undefined : data` ternary is gone.
- **Single-user mode restored to the plain logger.** #177 set `userId` to the account alias (`"default"`), a local label masquerading as a user identity, contradicting the `ToolContext.userId` doc that promises undefined outside team mode. Doc and code now agree.
- **Regression test**: `team-dispatch.test.ts` captures stderr around a session + tool call and asserts both identifiers appear on the session-created and dispatch lines.
- **CHANGELOG**: adds the Unreleased entry #177 shipped without, covering the feature as a whole.

## Verification

- `npm run lint` clean
- `npm test`: 825/825 pass, including the new attribution test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwGcaFoA9MuzSfXyrWJPKp