### PR TITLE
chore: prepare release 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.7.0](https://github.com/piotr-agier/google-drive-mcp/compare/v2.6.0...v2.7.0) (2026-09-02)
+
+Makes team-mode logs **attributable to a person**. Every team-mode log line — dispatch, session lifecycle, sign-in callback, and per-user tool logs — now carries the acting member's Google `sub` and email, so an audit trail can be read without joining opaque identifiers against the team store. Also hardens the per-user logger's error payloads against `JSON.stringify` mangling an `Error` into `{}` and against serializing a gaxios error's raw request config. Additive — no tool, parameter, or configuration changes, and single-user deployments log exactly as before.
+
 ### Features
 
 - **team:** log lines now name the acting user. Team-mode dispatch, session lifecycle (created / idle timeout / closed), sign-in callback, and per-user tool logs carry the member's Google `sub` and email, so an audit can tell who did what without joining an opaque `sub` against the team store. Error payloads passed to the per-user logger are rendered through the existing redaction helper instead of `JSON.stringify` (which turns an `Error` into `{}` and would serialize a gaxios error's raw request config). Single-user logs are unchanged ([#177](https://github.com/piotr-agier/google-drive-mcp/pull/177))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@piotr-agier/google-drive-mcp",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "license": "MIT",
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@piotr-agier/google-drive-mcp",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "mcpName": "io.github.piotr-agier/google-drive-mcp",
     "description": "Secure access to Google Drive, Docs, Sheets, Slides, and Calendar through MCP.",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
         "id": "1028345101"
     },
     "websiteUrl": "https://github.com/piotr-agier/google-drive-mcp#readme",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "@piotr-agier/google-drive-mcp",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"


### PR DESCRIPTION
Cuts **2.7.0** for the team-mode log attribution work that landed after the `v2.6.0` tag:

- `feat: Add user information to every log line item` (#177)
- `fix(team): attribute team logs by email and fix logWithUser payloads`

## Changes

- `package.json` / `package-lock.json`: `2.6.0` → `2.7.0`
- `server.json`: both version fields (`.version` and `.packages[0].version`) → `2.7.0`, so `registry:verify` sees a new version instead of reporting the 2.6.0 record as already published and silently skipping the MCP Registry update
- `CHANGELOG.md`: `[Unreleased]` notes moved into a dated `2.7.0` section with a `v2.6.0...v2.7.0` compare link; empty `[Unreleased]` header kept on top

## Why minor

Additive at the public contract — team-mode log lines gain the acting member's Google `sub` and email, with no tool, parameter, or configuration changes and no behavior change for single-user deployments. Consistent with the 2.6.0/2.5.0 precedent of reserving major for public-contract breaks.

## Verification

All run locally at 2.7.0 and passing:

- `npm run build`
- `npm run lint`
- `npm test` — 825 pass, 0 fail
- `npm run test:integration` — 543 pass, 0 fail
- `npm run registry:validate` — passed for `io.github.piotr-agier/google-drive-mcp@2.7.0`

Publishing stays a separate step: a GitHub Release on tag `v2.7.0` triggers `publish.yml` (npm via OIDC, then the MCP Registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHJ5RvFAB359fK16RFnxWx