### PR TITLE
fix(drive): verify shareFile's applied role and make permission-write reporting consistent

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -69,7 +69,7 @@ This server exposes 116 MCP tools across Google Drive, Docs, Sheets, Slides, and
 - **listPermissions** - List current sharing permissions on a file/folder
   - `fileId`: File or folder ID
 
-- **addPermission** - Add a new permission to a file/folder
+- **addPermission** - Add a new permission to a file/folder. If the principal already holds a permission, Drive updates it instead of creating a second one, and the requested role is applied even when it is a downgrade
   - `fileId`: File or folder ID
   - `type`: Permission target type (`user`, `group`, `domain`, `anyone`)
   - `role`: Permission role (`reader`, `commenter`, `writer`, `fileOrganizer`, `organizer`, `owner`)
@@ -88,7 +88,7 @@ This server exposes 116 MCP tools across Google Drive, Docs, Sheets, Slides, and
   - `permissionId`: Permission ID (optional if `emailAddress` is provided)
   - `emailAddress`: Email to find permission by (optional fallback)
 
-- **shareFile** - Share file with a user email (idempotent helper)
+- **shareFile** - Share file with a user email (idempotent helper). An existing permission for that user is updated to the requested role, even when it is a downgrade, instead of creating a duplicate
   - `fileId`: File or folder ID
   - `emailAddress`: Recipient email
   - `role`: Role (`reader`, `commenter`, `writer`)

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -547,7 +547,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "addPermission",
-    description: "Add a sharing permission to a file. Provide emailAddress for type 'user'/'group', domain for type 'domain', and neither for 'anyone'.",
+    description: "Add a sharing permission to a file. If the principal already holds a permission on the file, Drive updates that permission instead of creating a second one, and the requested role is applied even when it is a downgrade (asking for 'reader' for an existing 'writer' leaves them as 'reader'). Provide emailAddress for type 'user'/'group', domain for type 'domain', and neither for 'anyone'.",
     inputSchema: {
       type: "object",
       properties: {
@@ -591,7 +591,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "shareFile",
-    description: "Convenience wrapper to share a file with a user email",
+    description: "Convenience wrapper to share a file with a user email. If the user already holds a permission on the file, that permission's role is set to the requested one (even when it is a downgrade) instead of creating a duplicate.",
     inputSchema: {
       type: "object",
       properties: {
@@ -775,6 +775,59 @@ export const toolDefinitions: ToolDefinition[] = [
 // ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Permission writes
+// ---------------------------------------------------------------------------
+// Drive can apply a different role than the one requested: `permissions.create`
+// upserts onto a permission the principal already holds, and the resulting role
+// is not always the requested one. Every permission write below compares the
+// role Drive returned against the request and never reports the request as
+// the result.
+
+function describeRole(role: string | null | undefined): string {
+  return role ? `'${role}'` : 'no role';
+}
+
+type PermissionRoleOutcome =
+  | { ok: true; role: string; corrected: false }
+  | { ok: true; role: string; corrected: true; initiallyApplied: string | null }
+  | { ok: false; detail: string };
+
+/**
+ * Reconcile the role Drive applied on a `permissions.create` with the role
+ * requested. On a mismatch, issue one corrective `permissions.update` and
+ * report what happened: success with the role Drive first applied (so the
+ * caller learns an existing permission was changed, including a downgrade),
+ * or a failure describing what Drive holds now.
+ */
+async function reconcileCreatedPermissionRole(
+  drive: drive_v3.Drive,
+  fileId: string,
+  created: drive_v3.Schema$Permission,
+  requestedRole: string,
+): Promise<PermissionRoleOutcome> {
+  if (created.role === requestedRole) return { ok: true, role: requestedRole, corrected: false };
+  const applied = describeRole(created.role);
+  if (!created.id) {
+    return { ok: false, detail: `requested '${requestedRole}' but Drive applied ${applied} and returned no permission id to correct` };
+  }
+  try {
+    const corrected = await drive.permissions.update({
+      fileId,
+      permissionId: created.id,
+      requestBody: { role: requestedRole },
+      fields: 'id,role',
+      supportsAllDrives: true,
+    });
+    if (corrected.data.role === requestedRole) {
+      return { ok: true, role: requestedRole, corrected: true, initiallyApplied: created.role ?? null };
+    }
+    return { ok: false, detail: `requested '${requestedRole}' but Drive holds ${describeRole(corrected.data.role)} even after a corrective update` };
+  } catch (e: unknown) {
+    return { ok: false, detail: `requested '${requestedRole}' but Drive applied ${applied}, and the corrective update failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
 
 export async function handleTool(
   toolName: string,
@@ -1600,46 +1653,27 @@ export async function handleTool(
       });
 
       const principal = response.data.emailAddress || response.data.domain || data.emailAddress || data.domain || data.type;
-      // Drive can apply a different role than requested (e.g. upsert semantics
-      // when the principal already holds a permission on the file). Never
-      // report the requested role as fact — verify what came back, correct it
-      // once, and fail loudly if the mismatch survives.
-      if (response.data.role && response.data.role !== data.role) {
-        try {
-          const corrected = await ctx.getDrive().permissions.update({
-            fileId: data.fileId,
-            permissionId: response.data.id!,
-            requestBody: { role: data.role },
-            fields: 'id,role',
-            supportsAllDrives: true,
-          });
-          if (corrected.data.role === data.role) {
-            return {
-              content: [{
-                type: 'text',
-                text: `Permission added for ${principal}: Drive initially applied '${response.data.role}' instead of the requested '${data.role}' (likely an existing-permission upsert); corrected to '${corrected.data.role}'. Permission id: ${response.data.id}`,
-              }],
-              isError: false,
-            };
-          }
-          return {
-            content: [{
-              type: 'text',
-              text: `Permission MISMATCH for ${principal}: requested '${data.role}' but Drive holds '${corrected.data.role}' even after a corrective update. Verify with listPermissions and fix manually. Permission id: ${response.data.id}`,
-            }],
-            isError: true,
-          };
-        } catch (e: unknown) {
-          return {
-            content: [{
-              type: 'text',
-              text: `Permission MISMATCH for ${principal}: requested '${data.role}' but Drive applied '${response.data.role}', and the corrective update failed: ${e instanceof Error ? e.message : String(e)}. Verify with listPermissions.`,
-            }],
-            isError: true,
-          };
-        }
+      const permissionId = response.data.id ?? 'unknown';
+      const outcome = await reconcileCreatedPermissionRole(ctx.getDrive(), data.fileId, response.data, data.role);
+      if (!outcome.ok) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Permission MISMATCH for ${principal}: ${outcome.detail}. Verify with listPermissions and fix manually. Permission id: ${permissionId}`,
+          }],
+          isError: true,
+        };
       }
-      return { content: [{ type: 'text', text: `Permission added: ${response.data.id} (${response.data.role}) for ${principal}` }], isError: false };
+      if (outcome.corrected) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Permission added for ${principal}: Drive initially applied ${describeRole(outcome.initiallyApplied)} instead of the requested '${data.role}' (most likely because ${principal} already held a permission on this file); that permission's role was changed to '${outcome.role}'. Permission id: ${permissionId}`,
+          }],
+          isError: false,
+        };
+      }
+      return { content: [{ type: 'text', text: `Permission added: ${permissionId} (${outcome.role}) for ${principal}` }], isError: false };
     }
 
     case "updatePermission": {
@@ -1659,7 +1693,7 @@ export async function handleTool(
         return {
           content: [{
             type: 'text',
-            text: `Permission update MISMATCH: requested '${data.role}' for ${response.data.id} but Drive reports '${response.data.role}'. Verify with listPermissions.`,
+            text: `Permission update MISMATCH: requested '${data.role}' for ${response.data.id ?? data.permissionId} but Drive reports ${describeRole(response.data.role)}. Verify with listPermissions.`,
           }],
           isError: true,
         };
@@ -1733,6 +1767,16 @@ export async function handleTool(
           supportsAllDrives: true,
         });
 
+        if (updated.data.role !== data.role) {
+          return {
+            content: [{
+              type: 'text',
+              text: `Permission update MISMATCH for ${updated.data.emailAddress || data.emailAddress}: requested '${data.role}' but Drive reports ${describeRole(updated.data.role)}. Verify with listPermissions. Permission ID: ${existingPerm.id}`,
+            }],
+            isError: true,
+          };
+        }
+
         return {
           content: [{ type: 'text', text: `Updated existing permission for ${updated.data.emailAddress || data.emailAddress} to ${updated.data.role}. Permission ID: ${updated.data.id}` }],
           isError: false,
@@ -1752,8 +1796,29 @@ export async function handleTool(
         supportsAllDrives: true,
       });
 
+      const recipient = response.data.emailAddress || data.emailAddress;
+      const permissionId = response.data.id ?? 'unknown';
+      const outcome = await reconcileCreatedPermissionRole(ctx.getDrive(), data.fileId, response.data, data.role);
+      if (!outcome.ok) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Permission MISMATCH for ${recipient}: ${outcome.detail}. Verify with listPermissions and fix manually. Permission ID: ${permissionId}`,
+          }],
+          isError: true,
+        };
+      }
+      if (outcome.corrected) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Shared file with ${recipient} as ${outcome.role}: Drive initially applied ${describeRole(outcome.initiallyApplied)} instead of the requested '${data.role}' (most likely because ${recipient} already held a permission on this file); that permission's role was changed to '${outcome.role}'. Permission ID: ${permissionId}`,
+          }],
+          isError: false,
+        };
+      }
       return {
-        content: [{ type: 'text', text: `Shared file with ${response.data.emailAddress || data.emailAddress} as ${response.data.role}. Permission ID: ${response.data.id}` }],
+        content: [{ type: 'text', text: `Shared file with ${recipient} as ${outcome.role}. Permission ID: ${permissionId}` }],
         isError: false,
       };
     }

--- a/test/helpers/mock-google-apis.ts
+++ b/test/helpers/mock-google-apis.ts
@@ -52,7 +52,7 @@ function stub(tracker: CallTracker, name: string, defaultReturn: any = {}) {
     tracker.record(name, args);
     await drainMediaBody(args);
     if (impl) return impl(...args);
-    return { data: typeof defaultReturn === 'function' ? defaultReturn() : defaultReturn };
+    return { data: typeof defaultReturn === 'function' ? defaultReturn(...args) : defaultReturn };
   };
   fn._setImpl = (f: (...a: any[]) => any) => {
     impl = f;
@@ -96,9 +96,16 @@ export function createDriveMock() {
     create: stub(tracker, 'replies.create', { id: 'reply-1', content: 'reply text' }),
   };
   const permissions = {
-    create: stub(tracker, 'permissions.create', { id: 'perm-1', role: 'reader', emailAddress: 'user@example.com', type: 'user' }),
+    // Echo the requested role and type: the handlers verify the applied role against
+    // the request, so a fixed default would make every non-'reader' request look
+    // like a Drive-side mismatch. Tests that want a mismatch override with _setImpl.
+    create: stub(tracker, 'permissions.create', (req?: any) => ({
+      id: 'perm-1', role: req?.requestBody?.role ?? 'reader', emailAddress: 'user@example.com', type: req?.requestBody?.type ?? 'user',
+    })),
     list: stub(tracker, 'permissions.list', { permissions: [{ id: 'perm-1', role: 'reader', emailAddress: 'user@example.com', type: 'user' }] }),
-    update: stub(tracker, 'permissions.update', { id: 'perm-1', role: 'commenter', emailAddress: 'user@example.com', type: 'user' }),
+    update: stub(tracker, 'permissions.update', (req?: any) => ({
+      id: req?.permissionId ?? 'perm-1', role: req?.requestBody?.role ?? 'commenter', emailAddress: 'user@example.com', type: 'user',
+    })),
     delete: stub(tracker, 'permissions.delete', {}),
     get: stub(tracker, 'permissions.get', { id: 'perm-1', role: 'reader', emailAddress: 'user@example.com', type: 'user' }),
   };

--- a/test/integration/drive.test.ts
+++ b/test/integration/drive.test.ts
@@ -552,7 +552,7 @@ describe('Drive tools', () => {
         });
         assert.equal(res.isError, false);
         assert.ok(res.content[0].text!.includes("initially applied 'writer'"), res.content[0].text);
-        assert.ok(res.content[0].text!.includes("corrected to 'reader'"));
+        assert.ok(res.content[0].text!.includes("changed to 'reader'"), res.content[0].text);
         const updateCalls = ctx.mocks.drive.tracker.getCalls('permissions.update');
         assert.equal(updateCalls[updateCalls.length - 1].args[0].requestBody.role, 'reader');
       } finally {
@@ -592,6 +592,45 @@ describe('Drive tools', () => {
         assert.ok(res.content[0].text!.includes('MISMATCH'));
       } finally {
         ctx.mocks.drive.service.permissions.update._resetImpl();
+      }
+    });
+
+    it('addPermission reports a failed corrective update as an error that names the failure', async () => {
+      ctx.mocks.drive.service.permissions.create._setImpl(async () => ({
+        data: { id: 'perm-9', role: 'writer', emailAddress: 'user@example.com', type: 'user' },
+      }));
+      ctx.mocks.drive.service.permissions.update._setImpl(async () => {
+        throw new Error('insufficientFilePermissions');
+      });
+      try {
+        const res = await callTool(ctx.client, 'addPermission', {
+          fileId: 'file-1', emailAddress: 'user@example.com', role: 'reader', type: 'user',
+        });
+        assert.equal(res.isError, true);
+        assert.ok(res.content[0].text!.includes('MISMATCH'), res.content[0].text);
+        assert.ok(res.content[0].text!.includes('corrective update failed: insufficientFilePermissions'), res.content[0].text);
+      } finally {
+        ctx.mocks.drive.service.permissions.create._resetImpl();
+        ctx.mocks.drive.service.permissions.update._resetImpl();
+      }
+    });
+
+    it('addPermission treats a response without a role as a mismatch, like updatePermission does', async () => {
+      ctx.mocks.drive.service.permissions.create._setImpl(async () => ({
+        data: { id: 'perm-9', emailAddress: 'user@example.com', type: 'user' },
+      }));
+      try {
+        const res = await callTool(ctx.client, 'addPermission', {
+          fileId: 'file-1', emailAddress: 'user@example.com', role: 'reader', type: 'user',
+        });
+        // The default update mock echoes the requested role, so the correction succeeds.
+        assert.equal(res.isError, false, res.content[0].text);
+        assert.ok(res.content[0].text!.includes('initially applied no role'), res.content[0].text);
+        const updateCalls = ctx.mocks.drive.tracker.getCalls('permissions.update');
+        assert.equal(updateCalls.length, 1);
+        assert.equal(updateCalls[0].args[0].requestBody.role, 'reader');
+      } finally {
+        ctx.mocks.drive.service.permissions.create._resetImpl();
       }
     });
 
@@ -675,10 +714,18 @@ describe('Drive tools', () => {
     });
 
     it('updatePermission happy path', async () => {
-      const res = await callTool(ctx.client, 'updatePermission', {
-        fileId: 'file-1', permissionId: 'perm-1', role: 'commenter',
-      });
-      assert.equal(res.isError, false);
+      ctx.mocks.drive.service.permissions.update._setImpl(async () => ({
+        data: { id: 'perm-1', role: 'commenter', emailAddress: 'user@example.com', type: 'user' },
+      }));
+      try {
+        const res = await callTool(ctx.client, 'updatePermission', {
+          fileId: 'file-1', permissionId: 'perm-1', role: 'commenter',
+        });
+        assert.equal(res.isError, false);
+        assert.ok(res.content[0].text!.includes('perm-1 => commenter'), res.content[0].text);
+      } finally {
+        ctx.mocks.drive.service.permissions.update._resetImpl();
+      }
     });
 
     it('removePermission happy path', async () => {
@@ -709,6 +756,73 @@ describe('Drive tools', () => {
 
       assert.equal(res.isError, false);
       assert.ok(res.content[0].text!.includes('No changes needed'));
+    });
+
+    it('shareFile reports a mismatched role on the update path as an error', async () => {
+      ctx.mocks.drive.service.permissions.list._setImpl(async () => ({
+        data: { permissions: [{ id: 'perm-1', type: 'user', emailAddress: 'user@example.com', role: 'reader' }] },
+      }));
+      ctx.mocks.drive.service.permissions.update._setImpl(async () => ({
+        data: { id: 'perm-1', role: 'reader', emailAddress: 'user@example.com' },
+      }));
+      try {
+        const res = await callTool(ctx.client, 'shareFile', {
+          fileId: 'file-1', emailAddress: 'user@example.com', role: 'writer',
+        });
+        assert.equal(res.isError, true);
+        assert.ok(res.content[0].text!.includes('MISMATCH'), res.content[0].text);
+        assert.ok(res.content[0].text!.includes("requested 'writer' but Drive reports 'reader'"), res.content[0].text);
+      } finally {
+        ctx.mocks.drive.service.permissions.update._resetImpl();
+      }
+    });
+
+    it('shareFile corrects an upsert mismatch on the create path once and reports it', async () => {
+      // No user-type match in the pre-check (e.g. the address is a group), so
+      // shareFile creates — and Drive upserts onto the existing grant.
+      ctx.mocks.drive.service.permissions.list._setImpl(async () => ({ data: { permissions: [] } }));
+      ctx.mocks.drive.service.permissions.create._setImpl(async () => ({
+        data: { id: 'perm-9', role: 'writer', emailAddress: 'team@example.com', type: 'group' },
+      }));
+      ctx.mocks.drive.service.permissions.update._setImpl(async () => ({
+        data: { id: 'perm-9', role: 'reader' },
+      }));
+      try {
+        const res = await callTool(ctx.client, 'shareFile', {
+          fileId: 'file-1', emailAddress: 'team@example.com', role: 'reader',
+        });
+        assert.equal(res.isError, false, res.content[0].text);
+        assert.ok(res.content[0].text!.includes("initially applied 'writer'"), res.content[0].text);
+        assert.ok(res.content[0].text!.includes("changed to 'reader'"), res.content[0].text);
+        const updateCalls = ctx.mocks.drive.tracker.getCalls('permissions.update');
+        assert.equal(updateCalls.length, 1);
+        assert.equal(updateCalls[0].args[0].permissionId, 'perm-9');
+        assert.equal(updateCalls[0].args[0].requestBody.role, 'reader');
+      } finally {
+        ctx.mocks.drive.service.permissions.create._resetImpl();
+        ctx.mocks.drive.service.permissions.update._resetImpl();
+      }
+    });
+
+    it('shareFile reports a surviving mismatch on the create path as an error', async () => {
+      ctx.mocks.drive.service.permissions.list._setImpl(async () => ({ data: { permissions: [] } }));
+      ctx.mocks.drive.service.permissions.create._setImpl(async () => ({
+        data: { id: 'perm-9', role: 'writer', emailAddress: 'team@example.com', type: 'group' },
+      }));
+      ctx.mocks.drive.service.permissions.update._setImpl(async () => ({
+        data: { id: 'perm-9', role: 'writer' },
+      }));
+      try {
+        const res = await callTool(ctx.client, 'shareFile', {
+          fileId: 'file-1', emailAddress: 'team@example.com', role: 'reader',
+        });
+        assert.equal(res.isError, true);
+        assert.ok(res.content[0].text!.includes('MISMATCH'), res.content[0].text);
+        assert.ok(res.content[0].text!.includes('even after a corrective update'), res.content[0].text);
+      } finally {
+        ctx.mocks.drive.service.permissions.create._resetImpl();
+        ctx.mocks.drive.service.permissions.update._resetImpl();
+      }
     });
 
     it('addPermission forwards emailMessage to permissions.create', async () => {


### PR DESCRIPTION
## What

Follow-up to #178, addressing the review findings on it.

- **shareFile now verifies the applied role** on both its paths. Its update branch checks the response like `updatePermission`; its create branch goes through the same verify-and-correct-once flow as `addPermission`, extracted into a shared `reconcileCreatedPermissionRole` helper.
- **A response without a role is a mismatch everywhere.** `addPermission` used to skip verification when the role was absent while `updatePermission` treated it as an error.
- **Messages say what happened.** A corrected upsert now reads "that permission's role was changed to 'reader'" instead of "corrected to", so a downgrade is visible for what it is. The `addPermission` and `shareFile` tool descriptions (and `docs/tools.md`) state that an existing principal's role is set to the requested one, downgrades included.
- **Tests.** The permission mocks echo the requested role so the existing happy-path tests reflect Drive's normal behaviour instead of passing because the fixed default happened to match. The `updatePermission` happy path pins its mock explicitly. New tests cover the failed-corrective-update branch, the missing-role case, and shareFile's update mismatch, corrected create, and surviving create mismatch.

## Why

#178 closed the gap for `addPermission`/`updatePermission` but left `shareFile` echoing Drive's response unchecked. Its create path can hit the same upsert case for a group or domain principal, which its user-only pre-check does not match. The downgrade behaviour introduced by the corrective update was also undocumented.

Note on #178's description: on master before that PR the success message already printed the role from Drive's response, so it was not echoing the request. What was missing was that a mismatch looked identical to success; the caller had to compare the two roles by eye.

## How tested

`npm run lint`, `npm test` (833 pass), `npm run test:integration` (551 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
