### PR TITLE
fix(docs): stop sending an anchor Docs cannot resolve in addComment

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -328,11 +328,16 @@ This server exposes 116 MCP tools across Google Drive, Docs, Sheets, Slides, and
   - `documentId`: Document ID
   - `commentId`: Comment ID
 
-- **addComment** - Add a comment anchored to a specific text range
+- **addComment** - Add a comment quoting a text range
   - `documentId`: Document ID
-  - `startIndex`: Start index (1-based)
-  - `endIndex`: End index (exclusive)
+  - `startIndex`: Start index (1-based; or use `textToFind`)
+  - `endIndex`: End index (exclusive; or use `textToFind`)
+  - `textToFind`: Quote this exact text instead of using indices (case-sensitive)
+  - `matchInstance`: Which occurrence of `textToFind` to quote (1-based, default 1)
+  - `tabId`: Tab ID for multi-tab documents (defaults to the document body)
   - `commentText`: The comment content
+  - Provide either `startIndex`+`endIndex` or `textToFind`
+  - The comment appears in the document's comment panel and records the quoted passage. Google Docs does not support margin-anchored comments through any public API: the Docs API exposes no comment surface, and the Drive `anchor` field is [ignored by the Workspace editors](https://developers.google.com/workspace/drive/api/guides/manage-comments), which "treat these comments as un-anchored comments". Comments created here are therefore unanchored by design
 
 - **replyToComment** - Add a reply to an existing comment
   - `documentId`: Document ID

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1703,10 +1703,16 @@ const GetCommentSchema = z.object({
 
 const AddCommentSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
-  startIndex: z.number().int().min(1, "Start index must be at least 1"),
-  endIndex: z.number().int().min(1, "End index must be at least 1"),
+  startIndex: z.number().int().min(1, "Start index must be at least 1").optional(),
+  endIndex: z.number().int().min(1, "End index must be at least 1").optional(),
+  textToFind: z.string().min(1).optional(),
+  matchInstance: z.number().int().min(1).default(1),
+  tabId: z.string().optional(),
   commentText: z.string().min(1, "Comment text is required")
-});
+}).refine(
+  (d) => (d.startIndex != null && d.endIndex != null) || d.textToFind != null,
+  { message: "Provide either startIndex+endIndex or textToFind" },
+);
 
 const ReplyToCommentSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
@@ -2085,16 +2091,19 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "addComment",
-    description: "Add a comment anchored to a specific text range. Note: Due to Google API limitations, programmatic comments appear in 'All Comments' but may not be visibly anchored in the document UI.",
+    description: "Add a comment quoting a text range, targeted by startIndex+endIndex or by textToFind. The comment appears in the document's comment panel and records the quoted passage. Google Docs does not support margin-anchored comments through any public API, so the comment is unanchored by design; this is a platform limit, not a failure.",
     inputSchema: {
       type: "object",
       properties: {
         documentId: { type: "string", description: "The document ID" },
-        startIndex: { type: "number", description: "Start index (1-based)" },
-        endIndex: { type: "number", description: "End index (exclusive)" },
+        startIndex: { type: "number", description: "Start index (1-based; or use textToFind)" },
+        endIndex: { type: "number", description: "End index (exclusive; or use textToFind)" },
+        textToFind: { type: "string", description: "Quote this exact text instead of using indices (case-sensitive)" },
+        matchInstance: { type: "number", description: "Which occurrence of textToFind to quote (1-based, default 1)" },
+        tabId: { type: "string", description: "Tab ID for multi-tab documents (defaults to the document body)" },
         commentText: { type: "string", description: "The comment content" }
       },
-      required: ["documentId", "startIndex", "endIndex", "commentText"]
+      required: ["documentId", "commentText"]
     }
   },
   {
@@ -3600,35 +3609,69 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
       }
       const a = validation.data;
 
-      if (a.endIndex <= a.startIndex) {
-        return errorResponse("endIndex must be greater than startIndex");
+      const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
+
+      // Resolve the targeted body ONCE. Index spaces are per-tab, so the range
+      // lookup and the quote extraction must read the same content -- reading
+      // different bodies would quote text from the wrong tab.
+      let content: any[];
+      if (a.tabId) {
+        const resolved = await getTabBodyContent(ctx, a.documentId, a.tabId);
+        if (resolved.error) {
+          return errorResponse(resolved.error);
+        }
+        content = resolved.content!;
+      } else {
+        const doc = await docs.documents.get({ documentId: a.documentId });
+        content = doc.data.body?.content || [];
       }
 
-      // Get the document to extract quoted text
-      const docs = ctx.google.docs({ version: 'v1', auth: ctx.authClient });
-      const doc = await docs.documents.get({ documentId: a.documentId });
-
-      // Extract quoted text from the range
-      let quotedText = '';
-      const content = doc.data.body?.content || [];
-      for (const element of content) {
-        if (element.paragraph?.elements) {
-          for (const textElement of element.paragraph.elements) {
-            if (textElement.textRun) {
-              const elementStart = textElement.startIndex || 0;
-              const elementEnd = textElement.endIndex || 0;
-
-              if (elementEnd > a.startIndex && elementStart < a.endIndex) {
-                const text = textElement.textRun.content || '';
-                const startOffset = Math.max(0, a.startIndex - elementStart);
-                const endOffset = Math.min(text.length, a.endIndex - elementStart);
-                quotedText += text.substring(startOffset, endOffset);
-              }
-            }
-          }
+      let startIndex: number;
+      let endIndex: number;
+      if (a.textToFind) {
+        const range = await findTextRange(
+          ctx, a.documentId, a.textToFind, a.matchInstance, a.tabId, content);
+        if (range && 'error' in range) {
+          return errorResponse(range.error);
+        }
+        if (!range) {
+          return errorResponse(`textToFind "${a.textToFind}" not found in document.`);
+        }
+        startIndex = range.startIndex;
+        endIndex = range.endIndex;
+      } else {
+        startIndex = a.startIndex!;
+        endIndex = a.endIndex!;
+        if (endIndex <= startIndex) {
+          return errorResponse("endIndex must be greater than startIndex");
         }
       }
 
+      // buildFlatTextFromDoc walks paragraphs and nested tables. The previous
+      // scan looked only at top-level body paragraphs, so any range inside a
+      // table quoted '' and left the comment with no recoverable position.
+      const { flatText, offsetMap } = buildFlatTextFromDoc({ body: { content } });
+      let quotedText = '';
+      for (let i = 0; i < offsetMap.length; i++) {
+        if (offsetMap[i] >= startIndex && offsetMap[i] < endIndex) {
+          quotedText += flatText[i];
+        }
+      }
+      if (!quotedText) {
+        return errorResponse(
+          `Range [${startIndex}-${endIndex}] covers no text in the document.`);
+      }
+
+      // Deliberately NO anchor. Google Docs cannot be given an anchored comment
+      // through any public API: the Docs API has no comment surface at all, and
+      // Drive's `anchor` field is ignored by the Workspace editors, which
+      // "treat these comments as un-anchored comments" per
+      // https://developers.google.com/workspace/drive/api/guides/manage-comments
+      // Sending an anchor Docs cannot resolve is worse than sending none: the
+      // editor renders the thread under "Original content was deleted", so the
+      // comment reads as if the passage it refers to had been removed.
+      // quotedFileContent is what ties the comment to its passage, and is what
+      // listComments matches on to report character positions.
       const response = await ctx.getDrive().comments.create({
         fileId: a.documentId,
         fields: 'id,content,quotedFileContent,author,createdTime',
@@ -3636,26 +3679,14 @@ export async function handleTool(toolName: string, args: Record<string, unknown>
           content: a.commentText,
           quotedFileContent: {
             value: quotedText,
-            mimeType: 'text/html'
-          },
-          // Reverse-engineered anchor format for positioning comments.
-          // Not part of the public Drive API -- may break if Google changes internals.
-          // See: https://stackoverflow.com/questions/51789168
-          anchor: JSON.stringify({
-            r: a.documentId,
-            a: [{
-              txt: {
-                o: a.startIndex - 1,  // Drive API uses 0-based indexing
-                l: a.endIndex - a.startIndex,
-                ml: a.endIndex - a.startIndex
-              }
-            }]
-          })
+            mimeType: 'text/plain'
+          }
         }
       });
 
+      const snippet = quotedText.length > 60 ? `${quotedText.slice(0, 60)}...` : quotedText;
       return {
-        content: [{ type: "text", text: `Comment added successfully. Comment ID: ${response.data.id}` }],
+        content: [{ type: "text", text: `Comment added (id ${response.data.id}) quoting "${snippet}" at [${startIndex}-${endIndex}]. Google Docs shows API-created comments in the comment panel without a margin anchor.` }],
         isError: false
       };
     }

--- a/test/integration/docs.test.ts
+++ b/test/integration/docs.test.ts
@@ -124,6 +124,9 @@ describe('Docs tools', () => {
     // per-block override (e.g. insertText/deleteRange forcing a Google-Docs
     // mimeType) does not leak into later tests and make the suite order-dependent.
     ctx.mocks.drive.service.files.get._resetImpl();
+    // Same for docs.documents.get: several blocks install per-test document
+    // fixtures, which must not leak into later blocks.
+    ctx.mocks.docs.service.documents.get._resetImpl();
   });
 
   // --- createGoogleDoc ---
@@ -1583,23 +1586,110 @@ describe('Docs tools', () => {
 
   // --- addComment ---
   describe('addComment', () => {
-    it('happy path', async () => {
-      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
-        data: {
-          documentId: 'doc-1', title: 'My Doc',
-          body: { content: [{ paragraph: { elements: [{ textRun: { content: 'Hello World\n' }, startIndex: 1, endIndex: 13 }] } }] },
-        },
-      }));
+    const flatDoc = () => ({
+      documentId: 'doc-1', title: 'My Doc',
+      body: { content: [{ paragraph: { elements: [{ textRun: { content: 'Hello World\n' }, startIndex: 1, endIndex: 13 }] } }] },
+    });
+
+    it('happy path: quotes the range and sends NO anchor', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: flatDoc() }));
       const res = await callTool(ctx.client, 'addComment', {
-        documentId: 'doc-1', startIndex: 1, endIndex: 5, commentText: 'Great!',
+        documentId: 'doc-1', startIndex: 1, endIndex: 6, commentText: 'Great!',
       });
       assert.equal(res.isError, false);
       assert.ok(res.content[0].text!.includes('Comment added'));
+
+      const body = ctx.mocks.drive.tracker.getCalls('comments.create').at(-1)?.args?.[0]?.requestBody;
+      assert.equal(body.quotedFileContent.value, 'Hello');
+      assert.equal(body.quotedFileContent.mimeType, 'text/plain');
+      // The anchor Docs cannot resolve is what made the editor render these
+      // threads as "Original content was deleted". It must not come back.
+      assert.ok(!('anchor' in body), 'addComment must not send an anchor');
+    });
+
+    it('targets by textToFind and quotes the requested instance', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'My Doc',
+          body: { content: [{ paragraph: { elements: [{ textRun: { content: 'target and target again\n' }, startIndex: 1, endIndex: 25 }] } }] },
+        },
+      }));
+      const res = await callTool(ctx.client, 'addComment', {
+        documentId: 'doc-1', textToFind: 'target', matchInstance: 2, commentText: 'second one',
+      });
+      assert.equal(res.isError, false);
+      const body = ctx.mocks.drive.tracker.getCalls('comments.create').at(-1)?.args?.[0]?.requestBody;
+      assert.equal(body.quotedFileContent.value, 'target');
+      assert.ok(res.content[0].text!.includes('[12-18]'));
+    });
+
+    it('quotes text inside a table', async () => {
+      // The previous implementation scanned only top-level body paragraphs, so
+      // a range inside a table quoted '' and the comment lost its passage.
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({
+        data: {
+          documentId: 'doc-1', title: 'My Doc',
+          body: {
+            content: [{
+              table: {
+                tableRows: [{
+                  tableCells: [{
+                    content: [{ paragraph: { elements: [{ textRun: { content: 'CellText\n' }, startIndex: 5, endIndex: 14 }] } }],
+                  }],
+                }],
+              },
+            }],
+          },
+        },
+      }));
+      const res = await callTool(ctx.client, 'addComment', {
+        documentId: 'doc-1', startIndex: 5, endIndex: 9, commentText: 'about this cell',
+      });
+      assert.equal(res.isError, false);
+      const body = ctx.mocks.drive.tracker.getCalls('comments.create').at(-1)?.args?.[0]?.requestBody;
+      assert.equal(body.quotedFileContent.value, 'Cell');
+    });
+
+    it('quotes from the requested tab in a multi-tab document', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: mockDocs.multiTab() }));
+      const res = await callTool(ctx.client, 'addComment', {
+        documentId: 'doc-1', tabId: 'tab-2', startIndex: 1, endIndex: 7, commentText: 'on tab 2',
+      });
+      assert.equal(res.isError, false);
+      const body = ctx.mocks.drive.tracker.getCalls('comments.create').at(-1)?.args?.[0]?.requestBody;
+      // Index spaces are per-tab: [1-7) is 'Second' in tab-2, 'First ' in tab-1.
+      assert.equal(body.quotedFileContent.value, 'Second');
+    });
+
+    it('rejects a range that covers no text instead of commenting on nothing', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: flatDoc() }));
+      const res = await callTool(ctx.client, 'addComment', {
+        documentId: 'doc-1', startIndex: 500, endIndex: 520, commentText: 'nowhere',
+      });
+      assert.equal(res.isError, true);
+      assert.ok(res.content[0].text!.includes('covers no text'));
+      assert.equal(ctx.mocks.drive.tracker.getCalls('comments.create').length, 0);
+    });
+
+    it('reports when textToFind is absent', async () => {
+      ctx.mocks.docs.service.documents.get._setImpl(async () => ({ data: flatDoc() }));
+      const res = await callTool(ctx.client, 'addComment', {
+        documentId: 'doc-1', textToFind: 'nonexistent', commentText: 'x',
+      });
+      assert.equal(res.isError, true);
+      assert.equal(ctx.mocks.drive.tracker.getCalls('comments.create').length, 0);
     });
 
     it('validation: endIndex must be > startIndex', async () => {
       const res = await callTool(ctx.client, 'addComment', {
         documentId: 'doc-1', startIndex: 5, endIndex: 2, commentText: 'test',
+      });
+      assert.equal(res.isError, true);
+    });
+
+    it('validation: requires indices or textToFind', async () => {
+      const res = await callTool(ctx.client, 'addComment', {
+        documentId: 'doc-1', commentText: 'no target',
       });
       assert.equal(res.isError, true);
     });


### PR DESCRIPTION
## What

`addComment` no longer sends a hand-built Drive `anchor`. It quotes the target passage in `quotedFileContent`, extracts that passage with `buildFlatTextFromDoc` so ranges inside tables and in non-default tabs work, and accepts `textToFind`+`matchInstance` and `tabId` as targeting options. A range that covers no text is now an error instead of a comment about nothing.

Supersedes #180, which diagnosed the same symptom but through a request type that does not exist.

## Why

Google Docs cannot be given a margin-anchored comment through any public API. The Docs API exposes no comment surface at all, and the Drive guide to [managing comments](https://developers.google.com/workspace/drive/api/guides/manage-comments) states plainly that the anchor is stored but that "Google Workspace editor apps treat these comments as un-anchored comments". No anchor value changes that, a corrected revision id included.

Sending an anchor Docs cannot resolve is worse than sending none. The editor renders the thread under "Original content was deleted", so a reviewer opening the document sees a comment claiming the passage it refers to was removed.

Verified in the Docs UI on a scratch document before writing this. Comments created by the old code do render in the comment panel, and they render with that deleted-content header. A second comment created with an out-of-range target, so that quoted text was empty while the anchor was still sent, showed the same header. Quoted text varied and the label did not, which isolates the anchor as the trigger.

Two smaller defects fixed alongside:

- The quoted-text scan walked only top-level body paragraphs, so a range inside a table produced empty quoted text. `listComments` locates comments by searching for their quoted text and skips comments that have none, so those comments became position-less in this server's own output.
- `quotedFileContent.mimeType` was declared `text/html` while the value was raw document text. It is now `text/plain`.

## How tested

`npm test` passes, 888 tests. New coverage for `addComment`: the created payload carries no `anchor` key and a `text/plain` quote, targeting by `textToFind` picks the requested instance, a range inside a table quotes correctly, a range in a named tab quotes from that tab rather than the first, and an empty range is rejected without calling the Drive API. The no-anchor assertion is the regression guard.

## Open item for the reviewer

I confirmed that the anchor is what triggers the deleted-content header, and Google documents unanchored comments as supported and shown in the All Comments view. I could not directly observe how a comment with no anchor renders, because the shipped tool always sent one. Worth one look in the Docs UI against this branch before merging rather than taking it on inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTkXV2QWQMeQGDTbmYFNTM
